### PR TITLE
replace deepcopy with pickle / weko-search-ui

### DIFF
--- a/modules/weko-search-ui/tests/test_utils.py
+++ b/modules/weko-search-ui/tests/test_utils.py
@@ -227,7 +227,7 @@ def test_get_content_workflow():
     result["flow_id"] = item.flow_id
     result["flow_name"] = item.flow_define.flow_name
     result["item_type_name"] = item.itemtype.item_type_name.name
-    
+
     assert get_content_workflow(item) == result
 
 # def set_nested_item(data_dict, map_list, val):
@@ -265,11 +265,11 @@ def test_unpackage_import_file(app,mocker,mocker_itemtype):
     filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data", "unpackage_import_file/result.json")
     with open(filepath,encoding="utf-8") as f:
         result = json.load(f)
-    
+
     filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data", "unpackage_import_file/result_force_new.json")
     with open(filepath,encoding="utf-8") as f:
         result_force_new = json.load(f)
-    
+
     path = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data", "unpackage_import_file")
     with app.test_request_context():
         with set_locale('en'):
@@ -292,9 +292,9 @@ def test_getEncode():
         # {"file":"utf32be_bom_lf_items.csv","enc":"utf-32"},
         # {"file":"utf32le_bom_lf_items.csv","enc":"utf-32"},
          {"file":"big5.txt","enc":""},
-        
+
     ]
-    
+
     for f in csv_files:
         filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data", "csv",f['file'])
         print(filepath)
@@ -307,12 +307,18 @@ def test_read_stats_csv(app,mocker_itemtype):
     filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data", "csv","data.json")
     csv_file_name = "utf8_lf_items.csv"
     csv_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data", "csv",csv_file_name)
+    file_type = "csv"
     with open(filepath,encoding="utf-8") as f:
         data = json.load(f)
 
     with app.test_request_context():
         with set_locale('en'):
-            assert read_stats_csv(csv_file_path,csv_file_name) == data
+            res = read_stats_csv(csv_file_path,csv_file_name,file_type)
+            assert res["error"] == data["error"]
+            assert res["error_code"] == data["error_code"]
+            assert res["data_list"] == data["csv_data"]
+            assert res["item_type_schema"] == data["item_type_schema"]
+
 
 # def handle_convert_validate_msg_to_jp(message: str):
 # def handle_validate_item_import(list_record, schema) -> list:
@@ -340,7 +346,7 @@ def test_represents_int():
     assert represents_int("a") == False
     assert represents_int("30") == True
     assert represents_int("31.1") == False
-    
+
 
 # def get_item_type(item_type_id=0) -> dict:
 def test_get_item_type(mocker_itemtype):
@@ -471,7 +477,7 @@ def test_handle_fill_system_item(app,test_list_records,mocker):
         item_type_mapping = json.load(f)
     mocker.patch("weko_records.serializers.utils.get_mapping",return_value=item_map)
     mocker.patch("weko_records.api.Mapping.get_record",return_value=item_type_mapping)
-    
+
     filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data", "list_records/list_records_fill_system.json")
     with open(filepath,encoding="utf-8") as f:
         list_record = json.load(f)
@@ -492,7 +498,7 @@ def test_handle_fill_system_item(app,test_list_records,mocker):
         item2['metadata']['item_1617265215918']['subitem_1522305645492']=a
         item2['metadata']['item_1617265215918']['subitem_1600292170262']=""
         items.append(item2)
-    
+
     for a in ACCESS_RIGHT_TYPE_URI:
         item = copy.deepcopy(list_record[0])
         item['metadata']['item_1617265215918']['subitem_1522305645492']="VoR"
@@ -506,7 +512,7 @@ def test_handle_fill_system_item(app,test_list_records,mocker):
         item2['metadata']['item_1617186476635']['subitem_1522299639480']=a
         item2['metadata']['item_1617186476635']['subitem_1600958577026']=""
         items.append(item2)
-        
+
     for a in RESOURCE_TYPE_URI:
         item = copy.deepcopy(list_record[0])
         item['metadata']['item_1617265215918']['subitem_1522305645492']="VoR"
@@ -520,18 +526,18 @@ def test_handle_fill_system_item(app,test_list_records,mocker):
         item2['metadata']['item_1617258105262']['resourcetype']=a
         item2['metadata']['item_1617258105262']['resourceuri']=""
         items.append(item2)
-    
+
     # with open("items.json","w") as f:
     #     json.dump(items,f)
-    
+
     # with open("items_result.json","w") as f:
     #     json.dump(items_result,f)
-    
+
 
     # filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data/handle_fill_system_item/items.json")
     # with open(filepath,encoding="utf-8") as f:
     #     items = json.load(f)
-    
+
     # filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data/handle_fill_system_item/items_result.json")
     # with open(filepath,encoding="utf-8") as f:
     #     items_result = json.load(f)
@@ -567,7 +573,7 @@ def test_handle_fill_system_item(app,test_list_records,mocker):
 
 def test_DefaultOrderDict_deepcopy():
     import copy
-    
+
     data={
         "key0":"value0",
         "key1":"value1",
@@ -578,7 +584,7 @@ def test_DefaultOrderDict_deepcopy():
         }
     dict1 = defaultify(data)
     dict2 = copy.deepcopy(dict1)
-    
+
     for i, d in enumerate(dict2):
         if i in [0, 1] :
             assert d == "key" + str(i)

--- a/modules/weko-search-ui/weko_search_ui/admin.py
+++ b/modules/weko-search-ui/weko_search_ui/admin.py
@@ -21,12 +21,12 @@
 """Weko Search-UI admin."""
 
 import codecs
-import copy
 import json
 import os
 import tempfile
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
+import pickle
 
 from blinker import Namespace
 from celery import chord
@@ -524,10 +524,10 @@ class ItemImportView(BaseView):
                         "{}({})".format(item_type.item_type_name.name, item_type.id),
                         "{}items/jsonschema/{}".format(request.url_root, item_type.id),
                     ]
-                    ids_line = copy.deepcopy(WEKO_EXPORT_TEMPLATE_BASIC_ID)
-                    names_line = copy.deepcopy(WEKO_EXPORT_TEMPLATE_BASIC_NAME)
+                    ids_line = pickle.loads(pickle.dumps(WEKO_EXPORT_TEMPLATE_BASIC_ID, -1))
+                    names_line = pickle.loads(pickle.dumps(WEKO_EXPORT_TEMPLATE_BASIC_NAME, -1))
                     systems_line = ["#"] + ["" for _ in range(len(ids_line) - 1)]
-                    options_line = copy.deepcopy(WEKO_EXPORT_TEMPLATE_BASIC_OPTION)
+                    options_line = pickle.loads(pickle.dumps(WEKO_EXPORT_TEMPLATE_BASIC_OPTION, -1))
 
                     item_type = item_type.render
                     meta_list = {

--- a/modules/weko-search-ui/weko_search_ui/config.py
+++ b/modules/weko-search-ui/weko_search_ui/config.py
@@ -20,7 +20,7 @@
 
 """Configuration for weko-search-ui."""
 
-import copy
+import pickle
 
 from invenio_records_rest.config import RECORDS_REST_ENDPOINTS
 from invenio_records_rest.facets import terms_filter
@@ -99,7 +99,7 @@ WEKO_OPENSEARCH_SYSTEM_DESCRIPTION = (
 )
 WEKO_OPENSEARCH_IMAGE_URL = "static/favicon.ico"
 
-RECORDS_REST_ENDPOINTS = copy.deepcopy(RECORDS_REST_ENDPOINTS)
+RECORDS_REST_ENDPOINTS = pickle.loads(pickle.dumps(RECORDS_REST_ENDPOINTS, -1))
 RECORDS_REST_ENDPOINTS["recid"][
     "search_factory_imp"
 ] = "weko_search_ui.query.es_search_factory"
@@ -111,7 +111,7 @@ RECORDS_REST_ENDPOINTS["recid"]["search_index"] = "{}-weko".format(index_prefix)
 RECORDS_REST_ENDPOINTS["recid"]["search_type"] = "item-v1.0.0"
 
 # Opensearch endpoint
-RECORDS_REST_ENDPOINTS["opensearch"] = copy.deepcopy(RECORDS_REST_ENDPOINTS["recid"])
+RECORDS_REST_ENDPOINTS["opensearch"] = pickle.loads(pickle.dumps(RECORDS_REST_ENDPOINTS["recid"], -1))
 RECORDS_REST_ENDPOINTS["opensearch"][
     "search_factory_imp"
 ] = "weko_search_ui.query.opensearch_factory"

--- a/modules/weko-search-ui/weko_search_ui/rest.py
+++ b/modules/weko-search-ui/weko_search_ui/rest.py
@@ -20,7 +20,7 @@
 
 """Blueprint for Index Search rest."""
 
-import copy
+import pickle
 from functools import partial
 
 from flask import Blueprint, abort, current_app, jsonify, redirect, request, url_for
@@ -244,7 +244,7 @@ class IndexSearchResource(ContentNegotiatedMethodView):
         except BaseException:
             paths = []
         agp = rd["aggregations"]["path"]["buckets"]
-        rd["aggregations"]["aggregations"] = copy.deepcopy(agp)
+        rd["aggregations"]["aggregations"] = pickle.loads(pickle.dumps(agp, -1))
         nlst = []
         items_count = dict()
         public_indexes = Indexes.get_public_indexes_list()
@@ -333,10 +333,10 @@ class IndexSearchResource(ContentNegotiatedMethodView):
                 # get item type schema
                 item_type_id = hit["_source"]["_item_metadata"]["item_type_id"]
                 if item_type_id in item_type_list:
-                    item_type = copy.deepcopy(item_type_list[item_type_id])
+                    item_type = pickle.loads(pickle.dumps(item_type_list[item_type_id], -1))
                 else:
                     item_type = ItemType.query.filter_by(id=item_type_id).first()
-                    item_type_list[item_type_id] = copy.deepcopy(item_type)
+                    item_type_list[item_type_id] = pickle.loads(pickle.dumps(item_type, -1))
                 # heading
                 heading = get_heading_info(hit, lang, item_type)
                 hit["_source"]["heading"] = heading

--- a/modules/weko-search-ui/weko_search_ui/utils.py
+++ b/modules/weko-search-ui/weko_search_ui/utils.py
@@ -36,6 +36,7 @@ from functools import partial, reduce, wraps
 from io import StringIO
 from operator import getitem
 from time import sleep
+import pickle
 
 import bagit
 import redis
@@ -170,7 +171,7 @@ class DefaultOrderedDict(OrderedDict):
             args = tuple()
         else:
             args = (self.default_factory,)
-        return type(self), args, None, None, self.items()
+        return type(self), args, None, None, iter(self.items())
 
     def copy(self):
         """Modify inherited dict provides copy.
@@ -185,9 +186,8 @@ class DefaultOrderedDict(OrderedDict):
 
     def __deepcopy__(self, memo):
         """Modify inherited dict provides __deepcopy__."""
-        import copy
 
-        return type(self)(self.default_factory, copy.deepcopy(self.items()))
+        return type(self)(self.default_factory, pickle.loads(pickle.dumps(list(self.items()), -1)))
 
     def __repr__(self):
         """Return a nicely formatted representation string."""
@@ -2486,7 +2486,7 @@ def handle_check_id(list_record):
             item["warnings"] = (
                 item["warnings"] + warning if item.get("warnings") else warning
             )
- 
+
 
 def get_data_in_deep_dict(search_key, _dict={}):
     """
@@ -2725,7 +2725,7 @@ def handle_fill_system_item(list_record):
         # subitem_1600958577026
         #current_app.logger.debug(current_type)
         # access_right
-        
+
         if isinstance(node, list):
             for sub_node in node:
                 recursive_sub(keys[1:], sub_node, uri_key, current_type)


### PR DESCRIPTION
コード変更箇所の概要
* 基本的にはcopy.deepcopy(data)をpickle.loads(pickle.dumps(data,-1))に変換
* DefaultOrderedDict.__deepcopy__　に関連する処理の変更メソッド
  * __deepcopy__の戻り値は、self.items()をリスト化したオブジェクトをpickle化する処理を行った後、得られる値とした
  * pickle.loads(pickle.dumps(list(self.items())メソッド__reduce__の5つ目の戻り値を、イテラブルオブジェクトiter(self.items())に変更した
　　　上記2点の変更を両方とも加えた場合、テスト結果がFAILED→PASSEDになることを確認
* メソッドtest_read_stats_csvの仕様変更に合わせたテストコードの修正
  * 仕様変更に合わせ引数を追加
  * 比較対象辞書のkey名が異なっていたため、テストコードの修正により、発生していたAssertion Errorを解消　　　
  　　上記2点の変更を両方とも加えた場合、仕様変更後のコードでテスト結果がFAILED→PASSEDになることを確認
 
 以上です。コードレビューをよろしくお願いいたします。