### PR TITLE
fix tests

### DIFF
--- a/modules/invenio-oaiserver/invenio_oaiserver/response.py
+++ b/modules/invenio-oaiserver/invenio_oaiserver/response.py
@@ -8,6 +8,7 @@
 
 """OAI-PMH 2.0 response generator."""
 import copy
+import pickle
 import traceback
 from datetime import MINYEAR, datetime, timedelta
 
@@ -340,7 +341,7 @@ def is_pubdate_in_future(record):
 
 def is_private_index(record):
     """Check index of workflow is private."""
-    paths = copy.deepcopy(record.get('path'))
+    paths = pickle.loads(pickle.dumps(record.get('path'), -1))
     return not Indexes.is_public_state_and_not_in_future(paths)
 
 
@@ -442,7 +443,7 @@ def getrecord(**kwargs):
     e_metadata = SubElement(e_record,
                             etree.QName(NS_OAIPMH, 'metadata'))
 
-    etree_record = copy.deepcopy(record)
+    etree_record = pickle.loads(pickle.dumps(record, -1))
 
     if not etree_record.get('system_identifier_doi', None):
         etree_record['system_identifier_doi'] = get_identifier(record)
@@ -632,7 +633,7 @@ def listrecords(**kwargs):
                 )
                 e_metadata = SubElement(e_record, etree.QName(NS_OAIPMH,
                                                               'metadata'))
-                etree_record = copy.deepcopy(record)
+                etree_record = pickle.loads(pickle.dumps(record, -1))
                 if not etree_record.get('system_identifier_doi', None):
                     etree_record['system_identifier_doi'] = get_identifier(
                         record)

--- a/modules/invenio-oaiserver/tests/conftest.py
+++ b/modules/invenio-oaiserver/tests/conftest.py
@@ -278,7 +278,7 @@ def records(app):
     record_data=[
         {
             "path":["1557819692844"],
-            "publish_date":"2023-01-01",
+            "publish_date":"2100-01-01",
             "publish_status":0,
             "json":{
                 "_source":{
@@ -295,7 +295,7 @@ def records(app):
             },
         },
         {
-          "publish_date":"2022-08-09",
+          "publish_date":"2000-08-09",
           "publish_status":0,
           "json":{
               "_source":{
@@ -311,7 +311,7 @@ def records(app):
         },
         {
             "path":["1557819692844"],
-            "publish_date":"2022-08-09",
+            "publish_date":"2000-08-09",
             "publish_status":0,
             "json":{
               "_source":{
@@ -327,11 +327,10 @@ def records(app):
             "_oai":{"sets":[]},
             "system_identifier_doi":"DOI",
             "item_type_id":"1"
-
         },
         {
             "path":["1557819692844"],
-            "publish_date":"2022-08-09",
+            "publish_date":"2000-08-09",
             "publish_status":0,
             "json":{
               "_source":{

--- a/modules/invenio-oaiserver/tests/test_response.py
+++ b/modules/invenio-oaiserver/tests/test_response.py
@@ -119,8 +119,6 @@ def test_getrecord(app, records, item_type, mock_execute, mocker):
               'jpcoar': 'https://github.com/JPCOAR/schema/blob/master/1.0/',
               'dcterms': 'http://purl.org/dc/terms/', 'datacite': 'https://schema.datacite.org/meta/kernel-4/',
               'rioxxterms': 'http://www.rioxx.net/schema/v2.0/rioxxterms/'}}
-        mock_today = datetime.datetime(2022,8,8,0,0,0,0)
-        mocker.patch("datetime.datetime",**{"now.return_value":mock_today})
         mocker.patch("invenio_oaiserver.response.to_utc",side_effect=lambda x:x)
         mocker.patch("weko_index_tree.utils.get_user_groups",return_value=[])
         mocker.patch("weko_index_tree.utils.check_roles",return_value=True)
@@ -242,8 +240,6 @@ def test_getrecord_header_deleted(app,records,item_type,mock_execute,mocker):
               'dcndl': 'http://ndl.go.jp/dcndl/terms/', 'oaire': 'http://namespace.openaire.eu/schema/oaire/',
               'jpcoar': 'https://github.com/JPCOAR/schema/blob/master/1.0/', 'dcterms': 'http://purl.org/dc/terms/',
               'datacite': 'https://schema.datacite.org/meta/kernel-4/', 'rioxxterms': 'http://www.rioxx.net/schema/v2.0/rioxxterms/'}}
-        mock_today = datetime.datetime(2022,8,8,0,0,0,0)
-        mocker.patch("datetime.datetime",**{"now.return_value":mock_today})
         mocker.patch("invenio_oaiserver.response.to_utc",side_effect=lambda x:x)
         mocker.patch("weko_index_tree.utils.get_user_groups",return_value=[])
         mocker.patch("weko_index_tree.utils.check_roles",return_value=True)
@@ -357,8 +353,6 @@ def test_listrecords(app,records,item_type,mock_execute,mocker):
             'dcndl': 'http://ndl.go.jp/dcndl/terms/', 'oaire': 'http://namespace.openaire.eu/schema/oaire/',
             'jpcoar': 'https://github.com/JPCOAR/schema/blob/master/1.0/', 'dcterms': 'http://purl.org/dc/terms/',
             'datacite': 'https://schema.datacite.org/meta/kernel-4/', 'rioxxterms': 'http://www.rioxx.net/schema/v2.0/rioxxterms/'}}
-        mock_today = datetime.datetime(2022,8,8,0,0,0,0)
-        mocker.patch("datetime.datetime",**{"now.return_value":mock_today})
         mocker.patch("invenio_oaiserver.response.OAISet.get_set_by_spec",return_value=oaiset)
         mocker.patch("invenio_oaiserver.response.to_utc",side_effect=lambda x:x)
         mocker.patch("weko_index_tree.utils.get_user_groups",return_value=[])


### PR DESCRIPTION
pickle置換によるテストエラーの原因が、テストコードでの処理によるものだと分かりました。
修正したテストで挙動の確認ができたため、再度コードをpickleで置換した処理に変換しました。