### PR TITLE
Feature/jgss pre dev 3 (1)

### DIFF
--- a/modules/weko-records-ui/tests/test_views.py
+++ b/modules/weko-records-ui/tests/test_views.py
@@ -430,11 +430,11 @@ def test_get_usage_workflow(app, users, workflows):
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_views.py::test_get_workflow_detail -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 def test_get_workflow_detail(app,workflows):
     wf = workflows['workflow']
-    ret = get_workflow_detail(wf.id)
-    assert isinstance(wf,WorkFlow)
+    ret,isterm = get_workflow_detail(wf.id)
+    assert isinstance(ret,WorkFlow) and isinstance(isterm,bool)
 
     with pytest.raises(NotFound):
-        ret = get_workflow_detail(0)
+        ret,isterm = get_workflow_detail(0)
     
 
 # def default_view_method(pid, record, filename=None, template=None, **kwargs):

--- a/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/_macros.html
+++ b/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/_macros.html
@@ -37,6 +37,8 @@
         {% set item_type_id = workflow_detail.itemtype_id %}
         {% set flow_id = workflow_detail.flow_id %}
       {% endif %}
+      <input type="hidden" id="is_terms_only" name="is_terms_only"
+        value='{{ workflow_detail.is_terms_only }}'>
       {% if file.terms and start_guest_wf %}
         <a class="action-anchor" href="">
           <button class="img-rounded action-button button-sm term-condtion-modal"

--- a/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/_macros.html
+++ b/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/_macros.html
@@ -33,12 +33,12 @@
       {% set workflow_id = file | get_usage_workflow %}
       {% set start_guest_wf = workflow_id is not none and access_role == "open_restricted" %}
       {% if start_guest_wf %}
-        {% set workflow_detail = workflow_id | get_workflow_detail() %}
+        {% set workflow_detail,is_terms_only = workflow_id | get_workflow_detail() %}
         {% set item_type_id = workflow_detail.itemtype_id %}
         {% set flow_id = workflow_detail.flow_id %}
       {% endif %}
       <input type="hidden" id="is_terms_only" name="is_terms_only"
-        value='{{ workflow_detail.is_terms_only }}'>
+        value='{{ is_terms_only }}'>
       {% if file.terms and start_guest_wf %}
         <a class="action-anchor" href="">
           <button class="img-rounded action-button button-sm term-condtion-modal"

--- a/modules/weko-records-ui/weko_records_ui/views.py
+++ b/modules/weko-records-ui/weko_records_ui/views.py
@@ -64,7 +64,7 @@ from weko_workflow.api import WorkFlow
 
 from weko_records_ui.fd import add_signals_info
 from weko_records_ui.utils import check_items_settings, get_file_info_list
-from weko_workflow.utils import get_item_info, process_send_mail_tpl, set_mail_info 
+from weko_workflow.utils import get_item_info, process_send_mail_tpl, set_mail_info ,is_terms_of_use_only
 
 from .ipaddr import check_site_license_permission
 from .models import FilePermission, PDFCoverPageSettings
@@ -349,6 +349,8 @@ def get_workflow_detail(workflow_id):
     """
     workflow_detail = WorkFlow().get_workflow_by_id(workflow_id)
     if workflow_detail:
+        workflow_detail=vars(workflow_detail)
+        workflow_detail["is_terms_only"]=is_terms_of_use_only(workflow_id)
         return workflow_detail
     else:
         abort(404)
@@ -636,7 +638,7 @@ def default_view_method(pid, record, filename=None, template=None, **kwargs):
     file_url = ''
     if file_order >= 0 and files and files[file_order].get('url') and files[file_order]['url'].get('url'):
         file_url = files[file_order]['url']['url']
-
+    
     return render_template(
         template,
         pid=pid,

--- a/modules/weko-records-ui/weko_records_ui/views.py
+++ b/modules/weko-records-ui/weko_records_ui/views.py
@@ -349,9 +349,7 @@ def get_workflow_detail(workflow_id):
     """
     workflow_detail = WorkFlow().get_workflow_by_id(workflow_id)
     if workflow_detail:
-        workflow_detail=vars(workflow_detail)
-        workflow_detail["is_terms_only"]=is_terms_of_use_only(workflow_id)
-        return workflow_detail
+        return workflow_detail,is_terms_of_use_only(workflow_id)
     else:
         abort(404)
 

--- a/modules/weko-records-ui/weko_records_ui/views.py
+++ b/modules/weko-records-ui/weko_records_ui/views.py
@@ -638,7 +638,7 @@ def default_view_method(pid, record, filename=None, template=None, **kwargs):
     file_url = ''
     if file_order >= 0 and files and files[file_order].get('url') and files[file_order]['url'].get('url'):
         file_url = files[file_order]['url']['url']
-    
+
     return render_template(
         template,
         pid=pid,


### PR DESCRIPTION
制限公開アイテムが「提供方法：ワークフロー」に「利用規約のみ」、「提供方法：ロール」に「非ログインユーザー」が設定されている場合、
非ログインユーザがそのアイテムに申請をした時のメールアドレス入力を省略してDLできるようにしました。

modules/weko-records-ui/weko_records_ui/static/js/weko_records_ui/detail.js
・利用規約のみかつ非ログインユーザである場合にurl:/activity/init-guestにダウンロードリクエストを投げるメソッドterms_only_guest_downloadを追加しました。L77-115
・利用規約のみかつ非ログインユーザである場合に利用規約に同意した時にDLできるようにしました。L218-230
・利用規約のみで利用規約を設定していない場合にも非ログインユーザがDLをそのままできるようにしました。 L243-259

modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/_macros.html
・modules/weko-records-ui/weko_records_ui/views.pyによって渡される変数を保持する処理を加えました。

modules/weko-records-ui/weko_records_ui/views.py
・def get_workflow_detailにて返り値にワークフローが利用規約のみかどうかの変数を追加しました。