### PR TITLE
Feature/jgss pre dev 3-(3)

### DIFF
--- a/modules/weko-records-ui/weko_records_ui/fd.py
+++ b/modules/weko-records-ui/weko_records_ui/fd.py
@@ -418,12 +418,29 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
     """
     token = request.args.get('token', type=str)
     filename = kwargs.get("filename")
-    error_template = "weko_theme/error.html"
+    is_ajax = request.args.get('isajax')
+
+    def __make_error_response(is_ajax, error_msg):
+        error_template = "weko_theme/error.html"
+        if  is_ajax:
+            return error_msg, 401
+        else:
+            return render_template(error_template,
+                               error_msg)
+
+    # Guest Mailadress Check Modal
+    mailaddress = request.args.get('mailaddress')
+    if not mailaddress:
+        onetime_file_url = request.url
+        url=url_for(endpoint="invenio_records_ui.recid", onetime_file_url= onetime_file_url, pid_value = pid.pid_value, q="mailcheckflag")
+        return redirect(url)
+    
     # Parse token
     error, token_data = \
         parse_one_time_download_token(token)
     if error:
-        return render_template(error_template, error=error)
+        return __make_error_response(is_ajax, error_msg=error)
+
     record_id, user_mail, date, secret_token = token_data
 
     # Validate record status
@@ -438,15 +455,14 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
     is_valid, error = validate_onetime_download_token(
         onetime_download, filename, record_id, user_mail, date, secret_token)
     if not is_valid:
-        return render_template(error_template, error=error)
+        return __make_error_response(is_ajax, error_msg=error)
 
     _record_file_factory = _record_file_factory or record_file_factory
 
     # Get file object
     file_object = _record_file_factory(pid, record, filename)
-    if not file_object or not file_object.obj:
-        return render_template(error_template,
-                               error="{} does not exist.".format(filename))
+    if not file_object or not file_object.obj :
+        return __make_error_response(is_ajax, error_msg="{} does not exist.".format(filename))  
 
     # Create updated data
     update_data = dict(
@@ -461,26 +477,32 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
         try:
             error_msg = check_and_send_usage_report(extra_info, user_mail ,record, file_object)
             if error_msg:
-                return render_template(error_template, error=error_msg)
+                return __make_error_response(is_ajax, error_msg=error_msg)
             db.session.commit()
         except SQLAlchemyError as ex:
             current_app.logger.error("sqlalchemy error: {}".format(ex))
             db.session.rollback()
-            return render_template(error_template, error=_("Unexpected error occurred."))
+            return __make_error_response(is_ajax, error_msg=_("Unexpected error occurred."))
         except BaseException as ex:
             current_app.logger.error("Unexpected error: {}".format(ex))
             db.session.rollback()
-            return render_template(error_template, error=_("Unexpected error occurred."))
+            return __make_error_response(is_ajax, error_msg=_("Unexpected error occurred."))
 
         update_data['extra_info'] = extra_info
-
+ 
     # Update download data
     if not update_onetime_download(**update_data):
-        return render_template(error_template,
-                               error=_("Unexpected error occurred."))
+        return __make_error_response(is_ajax, error_msg=_("Unexpected error occurred."))
 
-    return _download_file(file_object, False, 'en', file_object.obj, pid,
-                          record)
+    #　Guest Mailaddress Check
+    if mailaddress == user_mail:
+        return _download_file(file_object, False, 'en', file_object.obj, pid,
+                              record)
+    else:
+        return __make_error_response(is_ajax, error_msg=_("Could not download file."))
+    
+    # return _download_file(file_object, False, 'en', file_object.obj, pid,
+    #                       record)
 
 def _is_terms_of_use_only(file_obj:dict , req :dict) -> bool:
     """

--- a/modules/weko-records-ui/weko_records_ui/fd.py
+++ b/modules/weko-records-ui/weko_records_ui/fd.py
@@ -429,11 +429,12 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
                                error_msg)
 
     # Guest Mailadress Check Modal
-    mailaddress = request.args.get('mailaddress')
-    if not mailaddress:
-        onetime_file_url = request.url
-        url=url_for(endpoint="invenio_records_ui.recid", onetime_file_url= onetime_file_url, pid_value = pid.pid_value, q="mailcheckflag")
-        return redirect(url)
+    if not current_user.is_authenticated:
+        mailaddress = request.args.get('mailaddress')
+        if not mailaddress:
+            onetime_file_url = request.url
+            url=url_for(endpoint="invenio_records_ui.recid", onetime_file_url= onetime_file_url, pid_value = pid.pid_value, q="mailcheckflag")
+            return redirect(url)
     
     # Parse token
     error, token_data = \
@@ -495,14 +496,15 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
         return __make_error_response(is_ajax, error_msg=_("Unexpected error occurred."))
 
     #　Guest Mailaddress Check
-    if mailaddress == user_mail:
-        return _download_file(file_object, False, 'en', file_object.obj, pid,
-                              record)
-    else:
-        return __make_error_response(is_ajax, error_msg=_("Could not download file."))
-    
-    # return _download_file(file_object, False, 'en', file_object.obj, pid,
-    #                       record)
+    if not current_user.is_authenticated:
+        if mailaddress == user_mail:
+            return _download_file(file_object, False, 'en', file_object.obj, pid,
+                                record)
+        else:
+            return __make_error_response(is_ajax, error_msg=_("Could not download file."))
+
+    return _download_file(file_object, False, 'en', file_object.obj, pid,
+                          record)
 
 def _is_terms_of_use_only(file_obj:dict , req :dict) -> bool:
     """

--- a/modules/weko-records-ui/weko_records_ui/static/js/weko_records_ui/detail.js
+++ b/modules/weko-records-ui/weko_records_ui/static/js/weko_records_ui/detail.js
@@ -267,4 +267,43 @@ require([
       });
     }
   });
-});
+  })
+  $('#close_btn, #modal_close_btn').on('click', function () {
+    document.location.href = location.pathname;
+    })
+  $('#mailcheck_download_modal').on('hidden.bs.modal', function () {
+    document.location.href = location.pathname;
+  })
+  $('#mailaddress_confirm_download').click(function () {
+   let mailaddress = document.getElementById('mail_form').value;
+   let input_error = document.getElementById('input_error_messsge').value;
+   let url_element = document.getElementById('url_element');
+   let onetime_file_url = url_element.dataset.onetime_file_url;
+   const get_uri =  onetime_file_url + '&mailaddress='+ mailaddress + '&isajax=true';
+   let item_detailes_url = location.pathname;
+   if(mailaddress == null || mailaddress == ""){
+     alert(input_error);
+     document.location.href = onetime_file_url;
+   }else{
+      $.ajax({
+        url: get_uri,
+        method: 'GET',
+        async: true,
+        success: function (response) {
+            let link = document.createElement("a");
+            link.download = "";
+            link.href = get_uri;
+            link.click();
+            $('#mailcheck_download_modal').modal('hide');
+            document.location.href = item_detailes_url;
+          },
+        error: function (error) {
+            response_text = error['responseText'];
+            alert(response_text);
+            $('#mailcheck_download_modal').modal('hide');
+            document.location.href = item_detailes_url;
+          }
+        })
+    }
+  }
+);

--- a/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/body_contents.html
+++ b/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/body_contents.html
@@ -456,6 +456,43 @@
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
+{%-if mailcheckflag %}
+  <div class="modal fade" tabindex="-1" role="dialog" id="mailcheck_download_modal">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" id="close_btn" data-dismiss="modal"
+                    aria-label="Close"><span aria-hidden="true">&times;</span>
+            </button>
+            <h4 class="modal-title">{{ _('Please input email address.') }}</h4>
+          </div>
+          <div class="modal-body">
+            <div class="form-group mail_form">
+              <label class="control-label"
+                    for="mail_form">{{ _('Email address') }}</label>
+              <input type="email" class="form-control" id="mail_form"
+                    aria-describedby="emailHelp"
+                    placeholder='{{ _("Email address") }}'>
+            </div>
+          </div>
+          <div class="modal-footer">
+                <button type="button" id="mailaddress_confirm_download" 
+                          class="btn btn-primary save-button">
+                  <span class="glyphicon glyphicon-check"></span>
+                {{ _('Send') }}
+                </button>
+                <button type="button" class="btn btn-info close-button"
+                      id="modal_close_btn" data-dismiss="modal">
+                  <span class="glyphicon glyphicon-remove"></span>
+                  {{ _('Cancel') }}
+                </button>
+            <input id= "url_element" type="hidden" data-onetime_file_url="{{ onetime_file_url }}">
+            <input id= "download_error_messsge" type="hidden" value="{{ _('Could not download file.') }}">
+          </div>
+        </div>
+    </div>
+  </div>
+{%- endif %}
 {% block css %}
 <style>
   #invenio-csl span.twitter-typeahead .tt-menu {
@@ -503,5 +540,12 @@
         $('#' + preview_id).click();
       }
     });
+    $(window).on('load', function () {
+    $("#mailcheck_download_modal").modal('toggle');
+     setTimeout(function () {
+       $("#mailcheck_download_modal").modal("show");
+    }, 0);
+    } 
+    );
   </script>
 {# {%- endblock javascript %} #}

--- a/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/body_contents.html
+++ b/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/body_contents.html
@@ -487,7 +487,7 @@
                   {{ _('Cancel') }}
                 </button>
             <input id= "url_element" type="hidden" data-onetime_file_url="{{ onetime_file_url }}">
-            <input id= "download_error_messsge" type="hidden" value="{{ _('Could not download file.') }}">
+            <input id= "input_error_messsge" type="hidden" value="{{ _('Please input email address.') }}">
           </div>
         </div>
     </div>

--- a/modules/weko-records-ui/weko_records_ui/translations/en/LC_MESSAGES/messages.po
+++ b/modules/weko-records-ui/weko_records_ui/translations/en/LC_MESSAGES/messages.po
@@ -1385,3 +1385,6 @@ msgstr ""
 
 msgid "Success Secret URL Generate"
 msgstr "Success: Secret URL Generate is succeed. Sent the URL to your email adress."
+
+msgid "Could not download file."
+msgstr ""

--- a/modules/weko-records-ui/weko_records_ui/translations/ja/LC_MESSAGES/messages.po
+++ b/modules/weko-records-ui/weko_records_ui/translations/ja/LC_MESSAGES/messages.po
@@ -657,3 +657,6 @@ msgstr "このデータは利用できません（権限がないため）。"
 
 msgid "Success Secret URL Generate"
 msgstr "成功: シークレットURLを生成し、あなたのメールアドレス宛に送信しました。"
+
+msgid "Could not download file."
+msgstr "ファイルをダウンロードできませんでした"

--- a/modules/weko-records-ui/weko_records_ui/views.py
+++ b/modules/weko-records-ui/weko_records_ui/views.py
@@ -637,6 +637,10 @@ def default_view_method(pid, record, filename=None, template=None, **kwargs):
     if file_order >= 0 and files and files[file_order].get('url') and files[file_order]['url'].get('url'):
         file_url = files[file_order]['url']['url']
 
+    mailcheckflag=request.args.get("q")
+
+    onetime_file_url = request.args.get("onetime_file_url")
+
     return render_template(
         template,
         pid=pid,
@@ -679,6 +683,8 @@ def default_view_method(pid, record, filename=None, template=None, **kwargs):
         flg_display_resourcetype = current_app.config.get('WEKO_RECORDS_UI_DISPLAY_RESOURCE_TYPE') ,
         search_author_flg=search_author_flg,
         show_secret_URL=_get_show_secret_url_button(record,filename),
+        mailcheckflag = mailcheckflag,
+        onetime_file_url = onetime_file_url,
         **ctx,
         **kwargs
     )


### PR DESCRIPTION
制限公開ワークフロー改修(3)：
非ログインユーザの「利用登録」「利用申請」および「二段階利用申請」ワークフローにおいて、ワンタイムアドレスクリック後メールアドレスチェックを行う機能の追加。

・modules/weko-records-ui/weko_records_ui/fd/file_download_onetime
　・def __make_error_response の追加　#L423-L429
　・Guest Mail Checkの処理を追加 #L431-L437 #L498-L504

　・（def __make_error_responseのelse: returnは、return render_template(error_template, error = error_msg) の誤り)

・modules/weko-records-ui/weko_records_ui/views/default_view_method
　・fd,pyで追加したクエリパラメータを受け取り、templateに付与する処理の追加 #L640-L642 #L686-L687

・modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/body_contents.html
　・mailcheckflagクエリパラメータを受け取った際のモーダルのhtmlを追加 #L459-L495 #L543-549

・modules/weko-records-ui/weko_records_ui/static/js/weko_records_ui/details.js
　・モーダルの処理を追加 #L271-L309

・modules/weko-records-ui/weko_records_ui/translations/en/LC_MESSAGES/messages.po #L1389-L1390
・modules/weko-records-ui/weko_records_ui/translations/ja/LC_MESSAGES/messages.po #L661-L662
