### PR TITLE
elasticsearch修正に伴う単体テストの追加です。

### DIFF
--- a/modules/weko-deposit/tests/test_receivers.py
+++ b/modules/weko-deposit/tests/test_receivers.py
@@ -98,6 +98,16 @@ def test_append_file_content(app, db, db_itemtype, users, db_userprofile, es_rec
             ret = append_file_content(sender, json, es_records[1][0]['record'])
             assert ret == None
             assert json['weko_shared_ids'] == []
+            
+        # with patch("weko_records.api.FeedbackMailList.get_mail_list_by_item_id", return_value=["xxxxxx@ivis.co.jp"]):
+        with patch("weko_records.api.RequestMailList.get_mail_list_by_item_id", return_value=["xxxxxx@ivis.co.jp"]):
+            jrc ={'content': True,'type': ['conference paper'], 'title': ['タイトル', 'title'], 'control_number': '1', '_oai': {'id': '1'}, '_item_metadata': OrderedDict([('pubdate', {'attribute_name': 'PubDate', 'attribute_value': '2022-08-20'}), ('item_1617186331708', {'attribute_name': 'Title', 'attribute_value_mlt': [{'subitem_1551255647225': 'タイトル', 'subitem_1551255648112': 'ja'}, {'subitem_1551255647225': 'title', 'subitem_1551255648112': 'en'}]}), ('item_1617258105262', {'attribute_name': 'Resource Type', 'attribute_value_mlt': [{'resourceuri': 'http://purl.org/coar/resource_type/c_5794', 'resourcetype': 'conference paper'}]}), ('item_title', 'title'), ('item_type_id', '1'), ('control_number', '1'), ('author_link', []), ('weko_shared_ids', []), ('owner', 5), ('owners', [5])]), 'itemtype': 'テストアイテムタイプ', 'publish_date': '2022-08-20', 'author_link': [], 'weko_creator_id': '5', 'weko_shared_ids': []}
+            jrc['content']=True
+            with patch("weko_deposit.receivers.json_loader", return_value=["a", jrc, "b"]):
+                ret = append_file_content(sender, json, es_records[1][0]['record'],None,arguments={"pipeline":""})
+                assert ret == None
+                assert json['weko_shared_ids'] == []
+                assert json['request_mail_list']
         """
         obj = es_records[1][0]["recid"]
         mail = FeedbackMailList(


### PR DESCRIPTION
elasticsearch修正に伴う単体テストコード修正です。
・weko-deposit/receivers.pyのappend_file_contentメソッド