### PR TITLE
Fix/w2023 23 request mail

### DIFF
--- a/modules/weko-records-ui/tests/test_api.py
+++ b/modules/weko-records-ui/tests/test_api.py
@@ -1,91 +1,227 @@
+from smtplib import SMTPException
 from mock import patch
-from unittest.mock import MagicMock
 import pytest
-import io
-from flask import Flask, json, jsonify, session, url_for, current_app
-from flask_security.utils import login_user
-from invenio_accounts.testutils import login_user_via_session
+from flask import current_app
 from pytest_mock import mocker
 
-from weko_records_ui.api import send_request_mail, create_captcha_image
-from weko_records_ui.errors import ContentsNotFoundError, InternalServerError, InvalidCaptchaError, InvalidEmailError
+from weko_records_ui.api import send_request_mail, create_captcha_image, validate_captcha_answer
+from weko_records_ui.errors import AuthenticationRequiredError, ContentsNotFoundError, InternalServerError, InvalidCaptchaError, InvalidEmailError, RequiredItemNotExistError
 from weko_redis.redis import RedisConnection
 
 # def send_request_mail(item_id, mail_info):
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_api.py::test_send_request_mail -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 def test_send_request_mail(app, make_request_maillist):
 
-    mail_info = {'from': 'test1@example.com',
-                 'subject': 'test_subject',
-                 'message': 'test_message',
-                 'key': '',
-                 'calculation_result': 1}
-    item_id = make_request_maillist[0]
-
-    with pytest.raises(ContentsNotFoundError):
-        send_request_mail(item_id,mail_info)
-
-    mail_info = {'from': 'test1@example.com',
-                 'subject': 'test_subject',
-                 'message': 'test_message',
-                 'key': 'test_key',
-                 'calculation_result': '1'}
-    item_id = make_request_maillist[0]
-
     redis_connection = RedisConnection()
     datastore = redis_connection.connection(db=app.config['CACHE_REDIS_DB'])
-    datastore.hmset(b'test_key',{b'calculation_result':b'10'})
+    datastore.hmset(b'test_key',{b'authorization_token':b'token'})
 
-    with pytest.raises(InvalidCaptchaError):
-        send_request_mail(item_id,mail_info)
+    correct_mail_info = {
+        'from': 'test1@example.com',
+        'subject': 'test_subject',
+        'message': 'test_message',
+        'key': 'test_key',
+        'authorization_token': 'token'
+    }
 
-    mail_info = {'from': 'test1@example.com',
-                'subject': 'test_subject',
-                'message': 'test_message',
-                'key': 'test_key',
-                'calculation_result': 1}
+    # TestCase: missing 'key' in request body
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'authorization_token': 'token'})
+
+    # TestCase: 'key' is empty
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'key': '',
+            'authorization_token': 'token'})
+
+    # TestCase: missing 'authorization_token' in reuqest body
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'key': 'test_key'})
+
+    # TestCase: empty 'authorization_token'
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'key': 'test_key',
+            'authorization_token': ''})
+
+    # TestCase: 'authorization_token' is wrong
+    item_id = make_request_maillist[0]
+    with pytest.raises(AuthenticationRequiredError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'key': 'test_key',
+            'authorization_token': 'token1'})
+
+    # TestCase: Empty mail list
     item_id = make_request_maillist[1]
-
-    redis_connection = RedisConnection()
-    datastore = redis_connection.connection(db=app.config['CACHE_REDIS_DB'])
-    datastore.hmset(b'test_key',{b'calculation_result':b'1'})
-
     with pytest.raises(ContentsNotFoundError):
-        send_request_mail(item_id,mail_info)
+        send_request_mail(item_id, correct_mail_info)
 
-    mail_info = {'from': 'あああああ',
-                'subject': 'test_subject',
-                'message': 'test_message',
-                'key': 'test_key',
-                'calculation_result': 1}
+    # TestCase: missing 'from' in request body
     item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'key': 'test_key',
+            'authorization_token': 'token'})
 
+    # TestCase: 'from' is empty
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': '',
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'key': 'test_key',
+            'authorization_token': 'token'})
+
+    # TestCase: Invalid 'from' format
+    item_id = make_request_maillist[0]
     with pytest.raises(InvalidEmailError):
-        send_request_mail(item_id,mail_info)
+        send_request_mail(item_id, {
+            'from': 'あああああ',
+            'subject': 'test_subject',
+            'message': 'test_message',
+            'key': 'test_key',
+            'authorization_token': 'token'})
 
-    #mocker.patch('flask_mail._Mail.send')
-    mail_info = {'from': 'test1@example.com',
-                 'subject': 'test_subject',
-                 'message': 'test_message',
-                 'key': 'test_key',
-                 'calculation_result': 1}
+    # TestCase: missing 'subject' in request body
     item_id = make_request_maillist[0]
-    msg_sender = mail_info['from']
-    msg_subject = mail_info['subject']
-    msg_body = msg_sender + current_app.config.get("WEKO_RECORDS_UI_REQUEST_MESSAGE") + mail_info['message']
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'message': 'test_message',
+            'key': 'test_key',
+            'authorization_token': 'token'})
+
+    # TestCase: 'subject' is empty
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': '',
+            'message': 'test_message',
+            'key': 'test_key',
+            'authorization_token': 'token'})
+
+    # TestCase: missing 'message' in reuqest body
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': 'test_subject',
+            'key': 'test_key',
+            'authorization_token': 'token'})
+
+    # TestCase: empty 'message'
+    item_id = make_request_maillist[0]
+    with pytest.raises(RequiredItemNotExistError):
+        send_request_mail(item_id, {
+            'from': 'test1@example.com',
+            'subject': 'test_subject',
+            'message': '',
+            'key': 'test_key',
+            'authorization_token': 'token'})
+
+    # TestCase: Request Mail Successful
+    #mocker.patch('flask_mail._Mail.send')
+    item_id = make_request_maillist[0]
+    msg_body = correct_mail_info['from'] + current_app.config.get("WEKO_RECORDS_UI_REQUEST_MESSAGE") + correct_mail_info['message']
     res_test ={
-        "from": msg_sender,
-        "subject": msg_subject,
+        "from": correct_mail_info['from'],
+        "subject": correct_mail_info['subject'],
         "message": msg_body
     }
     with app.test_request_context():
         with patch ("flask_mail._Mail.send"):
-            res = send_request_mail(item_id,mail_info)
-            assert res == res_test
+            status, response = send_request_mail(item_id, correct_mail_info)
+            assert status == True
+            assert response == res_test
+
+    # TestCase: exception occured
+    item_id = make_request_maillist[0]
+    with app.test_request_context():
+        with patch("flask_mail._Mail.send", side_effect=SMTPException):
+            with pytest.raises(InternalServerError):
+                send_request_mail(item_id, correct_mail_info)
+
+
+# def validate_captcha_answer(captcha_answer):
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_api.py::test_validate_captcha_answer -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
+def test_validate_captcha_answer(app):
+
+    redis_connection = RedisConnection()
+    datastore = redis_connection.connection(db=app.config['CACHE_REDIS_DB'])
+
+    datastore.hmset(b'test_key',{b'calculation_result':b'100'})
+
+    # TestCase: missing 'key' in request body
+    with pytest.raises(RequiredItemNotExistError):
+        validate_captcha_answer({
+            'calculation_result': 100
+        })
+
+    # TestCase: empty 'key' in request body
+    with pytest.raises(RequiredItemNotExistError):
+        validate_captcha_answer({
+            'key': '',
+            'calculation_result': 100
+        })
+
+    # TestCase: missing 'calculation_result' in request body
+    with pytest.raises(RequiredItemNotExistError):
+        validate_captcha_answer({
+            'key': 'test_key'
+        })
+
+    # TestCase: wrong 'calculation_result'
+    datastore.hmset(b'test_key',{b'calculation_result':b'100'})
+    with pytest.raises(InvalidCaptchaError):
+        validate_captcha_answer({
+            'key': 'test_key',
+            'calculation_result': 99
+        })
+    # check redis is empty
+    captcha_info = datastore.hgetall('test_key')
+    assert captcha_info == {}
+
+    # TestCase: correct calculation result
+    datastore.hmset(b'test_key',{b'calculation_result':b'100'})
+    status, response = validate_captcha_answer({
+        'key': 'test_key',
+        'calculation_result': 100
+    })
+    assert status == True
+    assert 'authorization_token' in response.keys()
+
 
 # def create_captcha_image(item_id, mail_info):
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_api.py::test_create_captcha_image -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 def test_create_captcha_image(app):
     with app.test_request_context():
-        ret = create_captcha_image()
-        assert ret[0] == True
+        status, response = create_captcha_image()
+        assert status == True
+        assert 'key' in response.keys()
+        assert 'image' in response.keys()
+        assert response.get('ttl') == 600

--- a/modules/weko-records-ui/tests/test_rest.py
+++ b/modules/weko-records-ui/tests/test_rest.py
@@ -22,10 +22,14 @@
 
 import copy
 from unittest.mock import MagicMock
+from pytest import fail
 from flask import json, url_for
 from mock import patch
+from redis import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.http import generate_etag
+
+from weko_redis.redis import RedisConnection
 
 def url(root, kwargs = {}):
     args = ["{key}={value}".format(key = key, value = value) for key, value in kwargs.items()]
@@ -568,143 +572,256 @@ def test_RequestMail_post_v1(app, client, db, make_request_maillist, users):
     version = 'v1'
     invalid_version = 'v0'
 
-    test_body = {
-                    "key": "test_key",
-                    "from":"test1@example.com",
-                    "subject":"test_subject",
-                    "message":"test_message",
-                    "calculation_result":1
-                }
+    correct_request_body = {
+        "key": "test_key",
+        "from":"test1@example.com",
+        "subject":"test_subject",
+        "message":"test_message",
+        "authorization_token": 'token',
+    }
 
-    pid_value = "1"
-    res = client.post(
-        f'/{invalid_version}/records/{pid_value}/request-mail',
-        headers = "",
-        json = test_body,
-        content_type='application/json',
-    )
+    correct_pid_value = 100
+    wrong_pid_value = 1000000
+
+    # TestCase: invalid version
     try:
-        json.loads(res.get_data())
-    except:
-        assert False
-    assert res.status_code == 400
-
-    pid_value = 1000000
-    res = client.post(
-        f'/{version}/records/{pid_value}/request-mail',
-        headers = "",
-        json = test_body,
-        content_type='application/json',
-    )
-    try:
-        json.loads(res.get_data())
-    except:
-        assert False
-    assert res.status_code == 404
-
-    test_body = {
-                    "key": "test_key",
-                    "subject":"test_subject",
-                    "message":"test_message",
-                    "calculation_result":1
-                }
-
-    pid_value = "100"
-    res = client.post(
-        f'/{version}/records/{pid_value}/request-mail',
-        headers = "",
-        json = test_body,
-        content_type='application/json',
-    )
-    try:
-        json.loads(res.get_data())
-    except:
-        assert False
-    assert res.status_code == 404
-
-    test_body = {
-                    "key": "test_key",
-                    "from":"test1@example.com",
-                    "subject":"test_subject",
-                    "message":"test_message",
-                    "calculation_result":1
-                }
-
-    pid_value = "100"
-    res_test = {"from":"test1@example.com","subject":"test_subject","message":"test_message"}
-    with patch("weko_records_ui.rest.send_request_mail", return_value=(True,res_test)):
         res = client.post(
-        f'/{version}/records/{pid_value}/request-mail',
-        json = test_body,
-        content_type='application/json',
-        )
-        try:
-            json.loads(res.get_data())
-        except:
-            assert False
-        assert res.status_code == 200
-
-    with patch('weko_workflow.api.WorkActivity.init_activity', side_effect=SQLAlchemyError):
-        test_body = {
-                    "key": "test_key",
-                    "from":"test1@example.com",
-                    "subject":"test_subject",
-                    "message":"test_message",
-                    "calculation_result":1
-                }
-
-        pid_value = "100"
-        res = client.post(
-            f'/{version}/records/{pid_value}/request-mail',
+            f'/{invalid_version}/records/{correct_pid_value}/request-mail',
             headers = "",
-            json = test_body,
+            json = correct_request_body,
             content_type='application/json',
         )
+    except:
+        fail()
+    assert res.status_code == 400
+
+    # TestCase: record not found
+    try:
+        res = client.post(
+            f'/{version}/records/{wrong_pid_value}/request-mail',
+            headers = "",
+            json = correct_request_body,
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 404
+
+    # TestCase: 'key' not found
+    try:
+        res = client.post(
+            f'/{version}/records/{correct_pid_value}/request-mail',
+            headers = "",
+            json = {
+                "from":"test1@example.com",
+                "subject":"test_subject",
+                "message":"test_message",
+                "authorization_token": 'token',
+            },
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 400
+
+    # TestCase: 'key' value is empty
+    try:
+        res = client.post(
+            f'/{version}/records/{correct_pid_value}/request-mail',
+            headers = "",
+            json = {
+                "key": '',
+                "from":"test1@example.com",
+                "subject":"test_subject",
+                "message":"test_message",
+                "authorization_token": 'token',
+            },
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 400
+
+    # TestCase: 'from' not found
+    try:
+        res = client.post(
+            f'/{version}/records/{correct_pid_value}/request-mail',
+            headers = "",
+            json = {
+                "key": "test_key",
+                "subject":"test_subject",
+                "message":"test_message",
+                "authorization_token": 'token',
+            },
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 400
+
+    # TestCase: 'from' value is empty
+    try:
+        res = client.post(
+            f'/{version}/records/{correct_pid_value}/request-mail',
+            headers = "",
+            json = {
+                "key": "test_key",
+                'from': '',
+                "subject":"test_subject",
+                "message":"test_message",
+                "authorization_token": 'token',
+            },
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 400
+
+    # TestCase: 'authorization_token' is not correct
+    try:
+        res = client.post(
+            f'/{version}/records/{correct_pid_value}/request-mail',
+            headers = "",
+            json = {
+                "key": "test_key",
+                "from":"test1@example.com",
+                "subject":"test_subject",
+                "message":"test_message",
+                "authorization_token": 'token1',
+            },
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 401
+
+    # TestCase: send mail success
+    res_test = {"from":"test1@example.com","subject":"test_subject","message":"test_message"}
+    with patch("weko_records_ui.rest.send_request_mail", return_value=(True,res_test)):
+        try:
+            res = client.post(
+                f'/{version}/records/{correct_pid_value}/request-mail',
+                json = correct_request_body,
+                content_type='application/json',
+            )
+        except:
+            fail()
+        assert res.status_code == 200
+
+    # TestCase: server error
+    with patch('weko_records_ui.rest.send_request_mail', side_effect=SQLAlchemyError):
+        try:
+            res = client.post(
+                f'/{version}/records/{correct_pid_value}/request-mail',
+                headers = "",
+                json = correct_request_body,
+                content_type='application/json',
+            )
+        except:
+            fail()
         assert res.status_code == 500
+
+
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_rest.py::test_CaptchaAnswerValidation_post_v1 -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
+def test_CaptchaAnswerValidation_post_v1(app, client, db):
+    version = 'v1'
+    invalid_version = 'v0'
+    res = None
+
+    correct_body = {
+        "key": "test_key",
+        "calculation_result": 100
+    }
+
+    redis_connection = RedisConnection()
+    datastore = redis_connection.connection(db=app.config['CACHE_REDIS_DB'])
+
+    datastore.hmset(b'test_key',{b'calculation_result':b'100'})
+
+    # TestCase: invalid api version
+    try:
+        res = client.post(
+            f'/{invalid_version}/captcha/validate',
+            json = correct_body,
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 400
+
+    # TestCase: captcha result validation success
+    datastore.hmset(b'test_key',{b'calculation_result':b'100'})
+    try:
+        res = client.post(
+            f'/{version}/captcha/validate',
+            json = correct_body,
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 200
+    assert 'authorization_token' in json.loads(res.get_data()).keys()
+
+    # TestCase: internal server error
+    with patch('weko_records_ui.rest.validate_captcha_answer', side_effect=RedisError()):
+        try:
+            res = client.post(
+                f'/{version}/captcha/validate',
+                json = correct_body,
+                content_type='application/json',
+            )
+        except:
+            fail()
+        assert res.status_code == 500
+
+    # TestCase: validate captcha if language is Japanese
+    datastore.hmset(b'test_key',{b'calculation_result':b'100'})
+    try:
+        res = client.post(
+            f'/{version}/captcha/validate',
+            headers = [("Accept-Language", "jpn")],
+            json = correct_body,
+            content_type='application/json',
+        )
+    except:
+        fail()
+    assert res.status_code == 200
+
 
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_rest.py::test_CreateCaptchaImage_get_v1 -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 def test_CreateCaptchaImage_get_v1(app, client, db):
     version = 'v1'
     invalid_version = 'v0'
+    res = None
 
-    res = client.get(
-        f'/{invalid_version}/captcha/image'
-    )
-
+    # TestCase: invalid api version
     try:
-        json.loads(res.get_data())
+        res = client.get(f'/{invalid_version}/captcha/image')
     except:
-        assert False
+        fail()
     assert res.status_code == 400
 
-    res = client.get(
-        f'/{version}/captcha/image'
-    )
-
+    # TestCase: create captcha image success
     try:
-        json.loads(res.get_data())
+        res = client.get(f'/{version}/captcha/image')
     except:
-        assert False
+        fail()
     assert res.status_code == 200
+    assert 'key' in json.loads(res.get_data()).keys()
+    assert 'image' in json.loads(res.get_data()).keys()
+    assert 'ttl' in json.loads(res.get_data()).keys()
 
+    # TestCase: internal server error
     with patch('weko_records_ui.rest.create_captcha_image', return_value = ("","")):
-        res = client.get(
-        f'/{version}/captcha/image'
-    )
+        try:
+            res = client.get(f'/{version}/captcha/image')
+        except:
+            fail()
+        assert res.status_code == 500
 
+    # TestCase: create captcha image if language is Japanese
     try:
-        json.loads(res.get_data())
+        res = client.get(f'/{version}/captcha/image', headers = [("Accept-Language", "jpn")])
     except:
-        assert False
-    assert res.status_code == 500
-
-    res = client.get(
-        f'/{version}/captcha/image',
-        headers = [("Accept-Language", "jpn")]
-    )
-
-    try:
-        json.loads(res.get_data())
-    except:
-        assert False
+        fail()
     assert res.status_code == 200

--- a/modules/weko-records-ui/weko_records_ui/api.py
+++ b/modules/weko-records-ui/weko_records_ui/api.py
@@ -15,18 +15,18 @@ from weko_redis.redis import RedisConnection
 
 def send_request_mail(item_id, mail_info):
 
-    # Validate CAPTCHA
+    # Validate token
     captcha_key = mail_info.get('key')
-    calculation_result = mail_info.get('calculation_result')
-    if not captcha_key or not calculation_result:
+    authorization_token = mail_info.get('authorization_token')
+    if not captcha_key or not authorization_token:
         raise ContentsNotFoundError()
 
     redis_connection = RedisConnection()
     datastore = redis_connection.connection(db=current_app.config['CACHE_REDIS_DB'])
-    captcha_answer = datastore.hgetall(captcha_key)
-    encoded_calc_answer = captcha_answer.get('calculation_result'.encode())
-    if encoded_calc_answer is None or calculation_result is None or \
-        (int(encoded_calc_answer.decode()) != calculation_result):
+    captcha_info = datastore.hgetall(captcha_key)
+    encoded_token = captcha_info.get('authorization_token'.encode())
+    if encoded_token is None or authorization_token is None or \
+        (encoded_token.decode() != authorization_token):
         raise InvalidCaptchaError()
 
     # Get mail recipients
@@ -46,7 +46,7 @@ def send_request_mail(item_id, mail_info):
     except Exception as ex:
         # Invalid email
         raise InvalidEmailError() # 400 Error
-    
+
     try:
         mail_cfg = _load_mail_cfg_from_db()
         _set_flask_mail_cfg(mail_cfg)
@@ -76,10 +76,43 @@ def send_request_mail(item_id, mail_info):
     return True, res_json
 
 
+def validate_captcha_answer(captcha_answer):
+
+    expiration_seconds = current_app.config.get('WEKO_RECORDS_UI_CAPTCHA_EXPIRATION_SECONDS', 900)
+
+    # Validate CAPTCHA
+    captcha_key = captcha_answer.get('key')
+    calculation_result = captcha_answer.get('calculation_result')
+    if not captcha_key or not calculation_result:
+        raise ContentsNotFoundError()
+
+    redis_connection = RedisConnection()
+    datastore = redis_connection.connection(db=current_app.config['CACHE_REDIS_DB'])
+    captcha_answer = datastore.hgetall(captcha_key)
+    encoded_calc_answer = captcha_answer.get('calculation_result'.encode())
+    # if calculation validation failed
+    if encoded_calc_answer is None or calculation_result is None or \
+        (int(encoded_calc_answer.decode()) != calculation_result):
+        # delete Redis info
+        datastore.delete(captcha_key)
+        raise InvalidCaptchaError()
+
+    authorization_token = captcha_answer.get('authorization_token'.encode())
+
+    # Reset expiration seconds
+    datastore.expire(captcha_key, expiration_seconds)
+
+    # Create response
+    res_json = {
+        "authorization_token": authorization_token
+    }
+    return True, res_json
+
+
 def create_captcha_image():
 
     expiration_seconds = current_app.config.get('WEKO_RECORDS_UI_CAPTCHA_EXPIRATION_SECONDS', 900)
-    ttl = expiration_seconds - 300
+    ttl = min(expiration_seconds, current_app.config.get('WEKO_RECORDS_UI_CAPTCHA_TTL_SECONDS', expiration_seconds))
 
     # Get CAPTCHA info
     captcha_info = get_captcha_info()
@@ -89,16 +122,23 @@ def create_captcha_image():
     random_salt = ''.join([random.choice(string.ascii_letters + string.digits) for _ in range(10)])
     key = hashlib.sha1((current_dt.strftime('%Y/%m/%d-%H:%M:%S') + random_salt).encode()).hexdigest()
 
-    # Set calculation answer
+    # Create Authorization custom token
+    random_salt = ''.join([random.choice(string.ascii_letters + string.digits) for _ in range(10)])
+    authorization_token = hashlib.sha256((current_dt.strftime('%Y/%m/%d-%H:%M:%S') + random_salt).encode()).hexdigest()
+
+    # Set calculation answer and authorization token
     redis_connection = RedisConnection()
     datastore = redis_connection.connection(db=current_app.config['CACHE_REDIS_DB'])
     datastore.hset(key, 'calculation_result', captcha_info['answer'])
+    datastore.hset(key, 'authorization_token', authorization_token)
     datastore.expire(key, expiration_seconds)
 
     # Create response
     res_json = {
         "key": key,
         'image': captcha_info['image'],
-        'ttl': ttl 
+        'ttl': ttl
     }
     return True, res_json
+
+

--- a/modules/weko-records-ui/weko_records_ui/config.py
+++ b/modules/weko-records-ui/weko_records_ui/config.py
@@ -663,6 +663,10 @@ WEKO_RECORDS_UI_REST_ENDPOINTS = {
         'route': '/<string:version>/captcha/image',
         'default_media_type': 'application/json',
     },
+    'validate_captcha_answer': {
+        'route': '/<string:version>/captcha/validate',
+        'default_media_type': 'application/json',
+    },
 }
 
 WEKO_RECORDS_UI_API_LIMIT_RATE_DEFAULT = ['100 per minute']
@@ -670,6 +674,8 @@ WEKO_RECORDS_UI_API_LIMIT_RATE_DEFAULT = ['100 per minute']
 WEKO_RECORDS_UI_API_ACCEPT_LANGUAGES = ['en', 'ja']
 
 WEKO_RECORDS_UI_CAPTCHA_EXPIRATION_SECONDS = 900
+
+WEKO_RECORDS_UI_CAPTCHA_TTL_SECONDS = 600
 
 WEKO_RECORDS_UI_NOTIFICATION_MESSAGE = "以下の内容のリクエストメールをデータ提供者に送信しました。\n\n-----------------------------------------------------------------------------\n\n"
 

--- a/modules/weko-records-ui/weko_records_ui/errors.py
+++ b/modules/weko-records-ui/weko_records_ui/errors.py
@@ -25,7 +25,7 @@
 """Index errors."""
 from flask_babelex import gettext as _
 from flask_babelex import get_locale
-from invenio_rest.errors import RESTException
+from invenio_rest.errors import RESTException, RESTValidationError
 
 
 class VersionNotFoundRESTError(RESTException):
@@ -46,11 +46,22 @@ class InvalidTokenError(RESTException):
     code = 400
     description = _('Invalid Tokens.')
 
+class RequiredItemNotExistError(RESTValidationError):
+    """Required Item not exists in request body error."""
+
+    description = _('Reqired item does not exist.')
+
 class InvalidCaptchaError(RESTException):
     """Invalid CAPTCHA calculation result error."""
 
     code = 400
-    description = _('The calculation results are different')
+    description = _('The calculation results are different.')
+
+class AuthenticationRequiredError(RESTException):
+    """Contents not found error."""
+
+    code = 401
+    description = _('Unauthorized.')
 
 class InvalidWorkflowError(RESTException):
     """Contents not found error."""

--- a/modules/weko-records-ui/weko_records_ui/static/js/weko_records_ui/request_mail.js
+++ b/modules/weko-records-ui/weko_records_ui/static/js/weko_records_ui/request_mail.js
@@ -1,107 +1,110 @@
 $('#request_mail_btn')?.on('click', () => {
-    const dt = new Date();
-    const CALCULATION_MESSAGE = document.getElementById("calculation_message_initial").value;
-    // Get captcha and show modal
-    $.ajax({
-        url: '/api/v1/captcha/image',
-        async: false,
-        method: 'GET',
-        success: function (response) {
-            $("#request_captcha").attr('src', "data:image/png;base64," + response.image)
-            $("#request_mail_dialog").modal("show");
-            $('#request_mail_sender').val("");
-            $('#subject').val("");
-            $('#body').val("");
-            $("#calculation_message").text(CALCULATION_MESSAGE);
-            $("#calculation_result").val("");
-            $("#key").val(response.key);
-            $("#ttl").val(response.ttl);
-            $("#dt").val(dt);
-        },
-        error: function (jqXHE, status ,msg) {
-          alert(msg);
-        }
-      });
-})
-
-$('#reload_captcha_btn')?.on('click', () => {
-    // Reload captcha and show modal
-    $.ajax({
-        url: '/api/v1/captcha/image',
-        async: false,
-        method: 'GET',
-        success: function (response) {
-            $("#request_captcha").attr('src', "data:image/png;base64," + response.image)
-        },
-        error: function (jqXHE, status ,msg) {
-          alert(msg);
-        }
-      });
+  const CALCULATION_MESSAGE = document.getElementById("calculation_message_initial").value;
+  $("#calculation_message").text(CALCULATION_MESSAGE);
+  clear_mail_form()
+  // Get captcha and show modal
+  load_captcha_image().done((response) => {
+    $("#request_mail_dialog").modal("show");
+  }).fail((jqXHE, status, msg) => {
+    alert(msg);
+  });
 })
 
 let mail_form = $('#request_mail_form')
 mail_form?.on('submit', (e) => {
-    // Get request mail info and post to send email
-    e.preventDefault();
-    // write content
-    const body_data = {
+  // Get request mail info and post to send email
+  e.preventDefault();
+
+  const ttl = $("#ttl").val();
+  const dt = $("#dt").val();
+  const nowDate = new Date();
+  const limitDateSeconds = new Date(dt).setSeconds(new Date(dt).getSeconds() + parseInt(ttl));
+  const limitDate = new Date(limitDateSeconds);
+  const FAILED_MESSAGE = document.getElementById("failed_message").value;
+  const CAPTCHA_IMAGE_TIMEOUT = document.getElementById("captcha_image_timeout").value;
+
+  if (nowDate > limitDate) {
+    $("#calculation_message").text(CAPTCHA_IMAGE_TIMEOUT);
+    load_captcha_image().done((response) => {
+      $("#calculation_result").val("");
+    }).fail(function (jqXHE, status, msg) {
+      alert(msg);
+    });
+  } else {
+    const webelement = $('#confirm_send_button');
+    webelement.prop('disabled', true);
+    const authorization_url = '/api/v1/captcha/validate';
+    const authorization_body = {
+      'key': $('#key').val(),
+      'calculation_result': parseInt($('#calculation_result').val(), 10)
+    };
+    $.ajax({
+      url: authorization_url,
+      method: 'POST',
+      data: JSON.stringify(authorization_body),
+      contentType: 'application/json',
+      dataType: 'json'
+    }).then((response) => {
+      const re = /records\/(.+)/;
+      const reg_result = re.exec(location.pathname);
+      const recid = reg_result[1];
+      const url = ['/api/v1/records', recid, 'request-mail'].join('/');
+      // write content
+      const request_mail_body = {
         'from': $('#request_mail_sender').val(),
         'subject': $('#subject').val(),
         'message': $('#body').val(),
         'key': $('#key').val(),
-        'calculation_result': parseInt($('#calculation_result').val(), 10)
-    }
-
-    const ttl = $("#ttl").val();
-    const dt = $("#dt").val();
-    const nowDate = new Date();
-    const limitDateSeconds =new Date(dt).setSeconds(new Date(dt).getSeconds() + parseInt(ttl));
-    const limitDate = new Date(limitDateSeconds);
-    const FAILED_MESSAGE = document.getElementById("failed_message").value;
-    const CAPTCHA_IMAGE_TIMEOUT = document.getElementById("captcha_image_timeout").value;
-  
-    if(nowDate > limitDate){
-      const dt = new Date();
-      $.ajax({
-        url: '/api/v1/captcha/image',
-        async: false,
-        method: 'GET',
-        success: function (response) {
-            $("#request_captcha").attr('src', "data:image/png;base64," + response.image);
-            $("#key").val(response.key);
-            $("#calculation_message").text(CAPTCHA_IMAGE_TIMEOUT);
-            $("#calculation_result").val("");
-            $("#dt").val(dt);
-        },
-        error: function (jqXHE, status ,msg) {
-          alert(msg);
-        }
+        'authorization_token': response.authorization_token
+      };
+      return $.ajax({
+        url: url,
+        method: 'POST',
+        data: JSON.stringify(request_mail_body),
+        contentType: 'application/json',
+        dataType: 'json'
       });
-    }else{
-    current_path_pattern = /records\/(.+)/.exec(location.pathname)
-    url = ['/api/v1/records', current_path_pattern[1], 'request-mail'].join('/')
-    const webelement = $('#confirm_send_button');
-    const EMAIL_SENT_SUCCESSFULLY =  document.getElementById("email_sent_successfully").value
-    webelement.prop('disabled' ,true);
-    $.ajax({
-      url: url,
-      method: 'POST',
-      data: JSON.stringify(body_data),
-      contentType:'application/json',
-      dataType: 'json',
-      success: function (response) {
-        webelement.prop('disabled',false);
-        alert(EMAIL_SENT_SUCCESSFULLY);
-        $("#request_mail_sender").val("");
-        $("#subject").val("");
-        $("#body").val("");
-        $("#calculation_result").val("");
-        $("#calculation_message").val("");
-      },
-      error: function (jqXHE, status ,msg) {
-        webelement.prop('disabled',false);
+    }).then((response) => {
+      const EMAIL_SENT_SUCCESSFULLY = document.getElementById("email_sent_successfully").value
+      webelement.prop('disabled', false);
+      alert(EMAIL_SENT_SUCCESSFULLY);
+      clear_mail_form()
+      $("#calculation_message").val("");
+    }).fail((jqXHE, status, msg) => {
+      webelement.prop('disabled', false);
+      if (jqXHE.status == 500) {
+        alert("Internal Server Error.")
+      } else {
         alert(FAILED_MESSAGE);
       }
+      load_captcha_image().done((response) => {
+        const CALCULATION_MESSAGE = document.getElementById("calculation_message_initial").value;
+        $("#calculation_result").val("");
+        $("#calculation_message").text(CALCULATION_MESSAGE);
+      }).fail(function (jqXHE, status, msg) {
+        alert(msg);
+      });
     });
-    }
+  }
 })
+
+function load_captcha_image() {
+  return $.ajax({
+    url: '/api/v1/captcha/image',
+    async: false,
+    method: 'GET'
+  }).then((response) => {
+    const dt = new Date();
+    $("#request_captcha").attr('src', "data:image/png;base64," + response.image)
+    $("#key").val(response.key);
+    $("#ttl").val(response.ttl);
+    $("#dt").val(dt);
+  })
+}
+
+function clear_mail_form() {
+  $('#request_mail_sender').val("");
+  $('#subject').val("");
+  $('#body').val("");
+  $("#calculation_result").val("");
+}


### PR DESCRIPTION
W2023-23 リクエストメール機能修正

- リクエストメール送信用APIからCAPTCHA認証を分離、別API化
- CAPTCHAの結果検証に失敗した場合、Redisから認証用データを削除
- 機能改修に伴うフロント、テストコード修正