### PR TITLE
パフォーマンス改善/バグ修正/facet_search.jsの実行タイミングの変更

### DIFF
--- a/modules/weko-search-ui/weko_search_ui/templates/weko_search_ui/body_facet_search.html
+++ b/modules/weko-search-ui/weko_search_ui/templates/weko_search_ui/body_facet_search.html
@@ -28,5 +28,5 @@
 <input class="body-facet-search-label" id="cancel" type="hidden" value="{{_('cancel')}}" />
 <div id="app-facet-search"></div>
 {%- block javascript %}
-{% assets "weko_facet_search_js" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}  
+{% assets "weko_facet_search_js" %}<script defer type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}  
 {%- endblock javascript %}


### PR DESCRIPTION
対象のバグ
- 『トップ』ボタン押下後のTOP画面表示でファセット検索項目チェックボックスの条件項目が表示されない。

対処内容
- defer属性を付与して、jsの実行タイミングを変更しました