### PR TITLE
パフォーマンス改善/バグ/詳細検索のクエリパラメータ維持

### DIFF
--- a/modules/weko-theme/weko_theme/static/js/weko_theme/top_page.js
+++ b/modules/weko-theme/weko_theme/static/js/weko_theme/top_page.js
@@ -218,12 +218,16 @@ require([
     function getFacetParameter() {
         let result = "";
         let params = window.location.search.substring(1).split('&');
-        const conds = ['page', 'size', 'sort', 'timestamp', 'search_type', 'q', 'title', 'creator', 'date_range1_from', 'date_range1_to','time'];
+        // 既に稼働しており、ユーザーからは簡易、詳細検索は併用できると認識されている可能性があるため、暫定対応を行う。
+        // const conds = ['page', 'size', 'sort', 'timestamp', 'search_type', 'q', 'title', 'creator', 'date_range1_from', 'date_range1_to','time'];
+        const conds = ['page', 'size', 'sort', 'timestamp', 'search_type', 'q','time'];
         for (let i = 0; i < params.length; i++) {
             var keyValue = decodeURIComponent(params[i]).split('=');
             var key = keyValue[0];
             var value = keyValue[1];
-            if(key && !conds.includes(key) && !key.startsWith("text")) {
+            //  暫定対応
+            // if(key && !conds.includes(key) && !key.startsWith("text")) {
+            if(key && !conds.includes(key)) {
                 result += "&" + encodeURIComponent(key) + "=" + encodeURIComponent(value);
             }
         }


### PR DESCRIPTION
バグ内容
- 詳細検索→簡易検索を行った場合、詳細検索のパラメータ（title、creator、text1、date_range1_from、date_range1_to）が消える

原因
- ファセット検索のパラメータを取得する関数getFacetParameterが本来の機能を実現できていないことによる影響
- URLから削除する詳細検索のキーを網羅できていない状況
- 正しくファセット検索用のパラメータだけを返すようにしてしまうと、既存の仕様と大きく変わってしまうため(詳細→簡易を行った際に詳細検索のパラメータが全て消えてしまう)、暫定対応として、簡易検索以外のパラメータを全て返すこととする

改修内容
- URLから削除する対象となっていたキー　'title', 'creator', 'date_range1_from', 'date_range1_to', text*　を削除対象外とした