### PR TITLE
パフォーマンス改善/バグ修正/コミュニティを考慮した詳細検索エリア

### DIFF
--- a/modules/weko-theme/weko_theme/static/js/weko_theme/search_detail.js
+++ b/modules/weko-theme/weko_theme/static/js/weko_theme/search_detail.js
@@ -482,7 +482,7 @@
 
             // Reused the condition for using advanced search from top_page.js.
             var urlParams = new URLSearchParams(window.location.search);
-            var isDetailSearch = Array.from(urlParams.keys()).length > 5
+            var isDetailSearch = Array.from(urlParams.keys()).length > 6
             if (isDetailSearch) {
                 if (urlParams.has('cur_index_id')) {
                     isDetailSearch = false;

--- a/modules/weko-theme/weko_theme/static/js/weko_theme/top_page.js
+++ b/modules/weko-theme/weko_theme/static/js/weko_theme/top_page.js
@@ -285,7 +285,7 @@ require([
 
         // 詳細検索からページ遷移した場合、詳細検索のアコーディオンを開いた状態にして、ボタンのテキストを「閉じる」にセット
         var urlParams = new URLSearchParams(window.location.search);
-        var isDetailSearch = Array.from(urlParams.keys()).length > 5  // 5は簡易検索の際のクエリの数。urlに詳細検索の使用状況を管理するパラメータを作るなど、別の方法を考えるべき。
+        var isDetailSearch = Array.from(urlParams.keys()).length > 6 // 6は簡易検索の際のクエリの数
         if (isDetailSearch) {
             // インデックスを開いた状態での簡易検索の判定
             if (urlParams.has('cur_index_id')) {

--- a/modules/weko-theme/weko_theme/static/js/weko_theme/top_page.js
+++ b/modules/weko-theme/weko_theme/static/js/weko_theme/top_page.js
@@ -285,7 +285,7 @@ require([
 
         // 詳細検索からページ遷移した場合、詳細検索のアコーディオンを開いた状態にして、ボタンのテキストを「閉じる」にセット
         var urlParams = new URLSearchParams(window.location.search);
-        var isDetailSearch = Array.from(urlParams.keys()).length > 6 // 6は簡易検索の際のクエリの数
+        var isDetailSearch = Array.from(urlParams.keys()).length > 6 // 6は簡易検索の際のクエリの数。urlに詳細検索の使用状況を管理するパラメータを作るなど、別の方法を考えるべき。
         if (isDetailSearch) {
             // インデックスを開いた状態での簡易検索の判定
             if (urlParams.has('cur_index_id')) {


### PR DESCRIPTION
コミュニティ機能を使用している状態のことを考慮できていなかったため、元の仕様に戻しました

以下の場合に詳細検索使用中と判断されてしまっていた
/search?page=1&size=20&sort=controlnumber&search_type=0&q=test&community=test1