### PR TITLE
パフォーマンス改善/結合テストバグ修正/P-002

### DIFF
--- a/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/detail.html
+++ b/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/detail.html
@@ -23,7 +23,7 @@
   {{ super() }}
   {% assets "weko_theme_js_treeview" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_theme_js_top_page" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
-  {% assets "weko_theme_js_detail_search" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "weko_theme_js_detail_search" %}<script defer src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_records_ui_dependencies_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_records_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   <script src="{{ url_for('static', filename='js/weko_records_ui/record_view_stats.js')}}"></script>

--- a/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/file_details.html
+++ b/modules/weko-records-ui/weko_records_ui/templates/weko_records_ui/file_details.html
@@ -34,7 +34,7 @@
   {% assets "weko_theme_js_treeview" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_theme_js_top_page" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   <!-- {% assets "weko_records_ui_cites_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %} -->
-  {% assets "weko_theme_js_detail_search" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "weko_theme_js_detail_search" %}<script defer src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_records_ui_dependencies_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_records_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_records_ui_preview_carousel_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}

--- a/modules/weko-search-ui/weko_search_ui/templates/weko_search_ui/admin/item_management_display.html
+++ b/modules/weko-search-ui/weko_search_ui/templates/weko_search_ui/admin/item_management_display.html
@@ -32,7 +32,7 @@
   {{ super() }}
   {% assets "weko_theme_js_treeview" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_theme_js_top_page" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
-  {% assets "weko_theme_js_detail_search" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "weko_theme_js_detail_search" %}<script defer src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "invenio_search_ui_search_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_search_ui_dependencies_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_search_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}

--- a/modules/weko-search-ui/weko_search_ui/templates/weko_search_ui/search.html
+++ b/modules/weko-search-ui/weko_search_ui/templates/weko_search_ui/search.html
@@ -49,7 +49,7 @@
   {{ super() }}
   {% assets "weko_theme_js_treeview" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_theme_js_top_page" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
-  {% assets "weko_theme_js_detail_search" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "weko_theme_js_detail_search" %}<script defer src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "invenio_search_ui_search_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_search_ui_dependencies_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_search_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}

--- a/modules/weko-theme/weko_theme/templates/weko_theme/admin/item_management_display.html
+++ b/modules/weko-theme/weko_theme/templates/weko_theme/admin/item_management_display.html
@@ -45,7 +45,7 @@
   {% assets "weko_records_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "invenio_search_ui_search_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_search_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
-  {% assets "weko_theme_js_detail_search" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "weko_theme_js_detail_search" %}<script defer src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_admin_admin_lte_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
 {%- endblock javascript %}
 

--- a/modules/weko-theme/weko_theme/templates/weko_theme/frontpage.html
+++ b/modules/weko-theme/weko_theme/templates/weko_theme/frontpage.html
@@ -32,7 +32,7 @@
   {{ super() }}
   {% assets "weko_theme_js_treeview" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_theme_js_top_page" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
-  {% assets "weko_theme_js_detail_search" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "weko_theme_js_detail_search" %}<script defer src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "invenio_search_ui_search_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_search_ui_dependencies_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "weko_search_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}


### PR DESCRIPTION
結合テストのバグ修正
バグ管理番号：P-002

#### バグ内容
- 詳細検索条件の項目数が2の時、詳細検索エリアは開かれるが、条件が保持されない

#### 原因
- 詳細検索情報を保持する処理を行うsearch_detail.jsと、詳細検索エリアの開閉を制御するtop_page.jsの実行タイミングによって、生成されているクエリパラメータに違いがあった
- 詳細検索の使用状況の判断は、各jsとも、クエリパラメータの数が6よりも大きいか否かで判断している
- 詳細検索項目を　タイトル、著者名　で検索した場合、各jsで取得できるクエリパラメータは以下の様になり、詳細検索エリアは開いているが、詳細検索条件は取得できていない状態になっていた（search_detail.jsには　size　がない）

top_page.js　：　page,size,sort,search_type,q,title,creator

search_detail.js　：　page,search_type,q,title,creator,sort

#### 対応内容
- search_detail.jsを呼び出すhtmlテンプレートにdefer属性を付与して実行順序を変更することで対応した