### PR TITLE
NII_WEKO3-86 ＜実装＞4. 【移行ツール】[定型レポート] 「インデックスアクセス回数」と各レポートの出力項目「登録インデックス名」が表示されない

### DIFF
--- a/modules/weko-index-tree/tests/test_api.py
+++ b/modules/weko-index-tree/tests/test_api.py
@@ -749,6 +749,14 @@ def test_indexes_get_index_tree(i18n_app,
         res = Indexes.get_public_indexes_list()
         assert res==['1', '2', '3', '11', '21', '22']
 
+        # get_public_indexes_list with target_date
+        res = Indexes.get_public_indexes_list(datetime(1999, 1, 1))
+        assert res==['2', '3', '21', '22']
+        res = Indexes.get_public_indexes_list(datetime(2022, 1, 1))
+        assert res==['1', '2', '3', '11', '21', '22']
+        res = Indexes.get_public_indexes_list(datetime(2030, 1, 1))
+        assert res==['1', '2', '3', '11', '21', '22']
+
         # have_children
         res = Indexes.have_children(1)
         assert res==True

--- a/modules/weko-index-tree/weko_index_tree/api.py
+++ b/modules/weko-index-tree/weko_index_tree/api.py
@@ -24,7 +24,7 @@ import pickle
 import os
 import orjson
 from copy import deepcopy
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from functools import partial
 from socketserver import DatagramRequestHandler
 
@@ -1763,10 +1763,15 @@ class Indexes(object):
             delete_oaiset_setting.delay(id_list)
 
     @classmethod
-    def get_public_indexes_list(cls, target_date=datetime.utcnow()):
+    def get_public_indexes_list(cls, target_date=datetime.now(timezone.utc)):
         """Get list id of public indexes at target date.
 
-        :return: path.
+        Args:
+            target_date (datetime): (Optional)
+                Check by public or not, at this datetime.
+                Defaults to `datetime.now(timezone.utc)`.
+        Returns:
+            list: public index id list
         """
         recursive_t = db.session.query(
             Index.parent.label("pid"),

--- a/modules/weko-index-tree/weko_index_tree/api.py
+++ b/modules/weko-index-tree/weko_index_tree/api.py
@@ -1763,8 +1763,8 @@ class Indexes(object):
             delete_oaiset_setting.delay(id_list)
 
     @classmethod
-    def get_public_indexes_list(cls):
-        """Get list id of public indexes.
+    def get_public_indexes_list(cls, target_date=datetime.utcnow()):
+        """Get list id of public indexes at target date.
 
         :return: path.
         """
@@ -1776,7 +1776,7 @@ class Indexes(object):
             Index.public_state.is_(True)
         ).filter(
             db.or_(Index.public_date.is_(None),
-                   Index.public_date < datetime.utcnow())
+                   Index.public_date < target_date)
         ).cte(name="recursive_t", recursive=True)
 
         rec_alias = aliased(recursive_t, name="rec")
@@ -1790,7 +1790,7 @@ class Indexes(object):
                 test_alias.public_state.is_(True)
             ).filter(
                 db.or_(test_alias.public_date.is_(None),
-                       test_alias.public_date < datetime.utcnow()))
+                       test_alias.public_date < target_date))
         )
 
         ids = []

--- a/modules/weko-index-tree/weko_index_tree/api.py
+++ b/modules/weko-index-tree/weko_index_tree/api.py
@@ -1781,7 +1781,7 @@ class Indexes(object):
             Index.public_state.is_(True)
         ).filter(
             db.or_(Index.public_date.is_(None),
-                   Index.public_date < target_date)
+                   Index.public_date <= target_date)
         ).cte(name="recursive_t", recursive=True)
 
         rec_alias = aliased(recursive_t, name="rec")
@@ -1795,7 +1795,7 @@ class Indexes(object):
                 test_alias.public_state.is_(True)
             ).filter(
                 db.or_(test_alias.public_date.is_(None),
-                       test_alias.public_date < target_date))
+                       test_alias.public_date <= target_date))
         )
 
         ids = []


### PR DESCRIPTION
移行ツール側でWEKO2でのログ記録日におけるインデックスの公開状態を取得するため、`Indexes.get_public_indexes_list`メソッドで日付の指定ができるよう修正しました。

また、NII_WEKO3-174 で課題としている既存ログにオープンアクセス判定結果を付与するマイグレーション作業の際にもこのメソッドが使用できるかと思います。