### PR TITLE
weko-index-tree マージ問題対する修正

### DIFF
--- a/modules/weko-index-tree/tests/data/mappings/item-v1.0.0.json
+++ b/modules/weko-index-tree/tests/data/mappings/item-v1.0.0.json
@@ -2,10 +2,8 @@
   "settings": {
     "number_of_shards": 1,
     "number_of_replicas": 1,
-    "index.max_ngram_diff":2,
-    "index.mapping.total_fields.limit": 50000,
-    "refresh_interval": "1s",
     "index.max_ngram_diff": 2,
+    "index.mapping.total_fields.limit": 50000,
     "analysis": {
       "tokenizer": {
         "ja_tokenizer": {
@@ -1218,4 +1216,4 @@
         }
       ]
   }
-
+}


### PR DESCRIPTION
21663b02b23ed467fea275a491d187a1acfc3ddc
の修正のみ

マージ時に複数作業者の変更が入っており、想定通りの挙動をしていなかった
