### PR TITLE
invenio-indexerでカバレッジ取得できない問題　解消

### DIFF
--- a/modules/invenio-indexer/tox.ini
+++ b/modules/invenio-indexer/tox.ini
@@ -13,15 +13,15 @@ testpaths = tests
 
 [coverage:run]
 source =
-    invenio-indexer
+    invenio_indexer
     tests
 
 [coverage:paths]
 source =
-    invenio-indexer
+    invenio_indexer
     tests
-    .tox/*/lib/python*/site-packages/invenio-indexer
-    .tox/*/lib/python*/site-packages/invenio-indexer/tests
+    .tox/*/lib/python*/site-packages/invenio_indexer
+    .tox/*/lib/python*/site-packages/invenio_indexer/tests
 
 [flake8]
 max-line-length = 119
@@ -59,7 +59,7 @@ deps =
     pytest>=3
     pytest-cov
 commands =
-    pytest --cov=invenio-indexer tests -v --cov-report=term --basetemp="{envtmpdir}" {posargs}
+    pytest --cov=invenio_indexer tests -v --cov-report=term --basetemp="{envtmpdir}" {posargs}
 
 [testenv:c1]
 passenv = LANG
@@ -68,7 +68,7 @@ deps =
     pytest-cov
     -rrequirements2.txt
 commands =
-    pytest --cov=invenio-indexer tests -v --cov-branch --cov-report=term --cov-report=xml --cov-report=html --basetemp="{envtmpdir}" {posargs}
+    pytest --cov=invenio_indexer tests -v --cov-branch --cov-report=term --cov-report=xml --cov-report=html --basetemp="{envtmpdir}" {posargs}
 
 [testenv:lint]
 passenv = LANG
@@ -81,7 +81,7 @@ commands =
     black .
     isort .
     flake8 .
-    mypy invenio-indexer
+    mypy invenio_indexer
 
 
 [testenv:radon]
@@ -89,6 +89,6 @@ passenv = LANG
 deps =
     radon
 commands =
-    radon cc invenio-indexer
-    radon mi invenio-indexer
+    radon cc invenio_indexer
+    radon mi invenio_indexer
 


### PR DESCRIPTION
invenio-indexerでカバレッジ取得できない問題　解消

フォルダパス指定が誤っていたものを修正