### PR TITLE
上書き問題修正

### DIFF
--- a/modules/invenio-stats/invenio_stats/aggregations.py
+++ b/modules/invenio-stats/invenio_stats/aggregations.py
@@ -316,9 +316,7 @@ class StatAggregator(object):
                         index_name = res.hits.hits[0]['_index']
 
                 rtn_data = {
-                    "_id": "{0}-{1}".format(
-                        aggregation["key"], interval_date.strftime(self.doc_id_suffix)
-                    ),
+                    "_id": aggregation["key"],
                     "_index": index_name,
                     "_source": aggregation_data,
                 }

--- a/modules/invenio-stats/invenio_stats/aggregations.py
+++ b/modules/invenio-stats/invenio_stats/aggregations.py
@@ -316,7 +316,7 @@ class StatAggregator(object):
                         index_name = res.hits.hits[0]['_index']
 
                 rtn_data = {
-                    "_id": aggregation["key"],
+                    "_id": '{0}'.format(aggregation['key']),
                     "_index": index_name,
                     "_source": aggregation_data,
                 }

--- a/modules/invenio-stats/invenio_stats/contrib/event_builders.py
+++ b/modules/invenio-stats/invenio_stats/contrib/event_builders.py
@@ -77,6 +77,7 @@ def file_download_event_builder(event, sender_app, obj=None, **kwargs):
                 "is_billing_item": obj.is_billing_item,
                 "billing_file_price": obj.billing_file_price,
                 "user_group_list": obj.user_group_list,
+                "event_type": "file-download",
                 # Who:
                 **get_user()
             }
@@ -110,6 +111,7 @@ def file_preview_event_builder(event, sender_app, obj=None, **kwargs):
                 "is_billing_item": obj.is_billing_item,
                 "billing_file_price": obj.billing_file_price,
                 "user_group_list": obj.user_group_list,
+                "event_type": "file-preview",
                 # Who:
                 **get_user()
             }
@@ -131,11 +133,12 @@ def build_celery_task_unique_id(doc):
 
 def build_file_unique_id(doc):
     """Build file unique identifier."""
-    key = "{0}_{1}_{2}_{3}".format(
+    key = "{0}_{1}_{2}_{3}_{4}".format(
         doc["bucket_id"],
         doc["file_id"],
         doc["remote_addr"],
-        doc["unique_session_id"]
+        doc["unique_session_id"],
+        doc["event_type"]
     )
     doc["unique_id"] = str(uuid.uuid3(uuid.NAMESPACE_DNS, key))
     doc["hostname"] = "{}".format(resolve_address(doc["remote_addr"]))

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -102,14 +102,19 @@ class _StataModelBase(Timestamp):
         query = cls.get_by_date(query, start_date, end_date)
         
         # index ILIKE 'tenant1-events-stats-[event-type]'
-        condition_1 = cls.index.ilike(beforeindex)
+        condition_1 = cls.index.ilike(beforeindex + "%")
         
         # source->>'event_type' = '[event-type]'
-        condition_2 = cls.index.ilike(_index + "%") & (func.jsonb_extract_path_text(cls.source, "event_type") == event_type)
+        condition_2_1 = cls.index.ilike(_index + "%") 
+        condition_2_2 = func.jsonb_extract_path_text(cls.source, "event_type") == event_type
+        
         query = query.filter(
             or_(
                 condition_1,
-                condition_2
+                and_(
+                    condition_2_1,
+                    condition_2_2
+                )
             )
         )
         

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -34,7 +34,7 @@ class _StataModelBase(Timestamp):
     id = db.Column(db.String(100), primary_key=True)
     source_id = db.Column(db.String(100))
     index = db.Column(db.String(100), nullable=False)
-    type = db.Column(db.String(50), nullable=False)
+    type = db.Column(db.String(50))
     source = db.Column(
         db.JSON()
         .with_variant(postgresql.JSONB(none_as_null=True), "postgresql",)
@@ -197,6 +197,7 @@ class _StataModelBase(Timestamp):
             db.session.commit()
             return True
         except SQLAlchemyError as err:
+            print("Unexpected error: {}".format(err))
             current_app.logger.error("Unexpected error: {}".format(err))
             db.session.rollback()
             return False

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -202,7 +202,6 @@ class _StataModelBase(Timestamp):
             db.session.commit()
             return True
         except SQLAlchemyError as err:
-            print("Unexpected error: {}".format(err))
             current_app.logger.error("Unexpected error: {}".format(err))
             db.session.rollback()
             return False

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -181,7 +181,7 @@ class _StataModelBase(Timestamp):
                     'source_id': data_object.get("_id"),
                     'index': data_object.get("_index"),
                     'type': data_object.get("_type"),
-                    'source': json.dumps(data_object.get("_source")),
+                    'source': data_object.get("_source"),
                     'date': date
                 }
             else:

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -86,11 +86,15 @@ class _StataModelBase(Timestamp):
     ):
         """
         Get stats data by event type, supporting both old and new versions of data.
-        :param _index: event index for filtering.
-        :param event_type: the target event type (e.g., 'file-download').
-        :param start_date: start date for filtering.
-        :param end_date: end date for filtering.
-        :return: List of filtered data.
+
+        Args:
+            _index (str): Event index for filtering.
+            event_type (str): The target event type (e.g., 'file-download').
+            start_date (str): Start date for filtering.
+            end_date (str): End date for filtering.
+
+        Returns:
+            list: List of filtered data.
         """
         from sqlalchemy import func, or_, and_
         

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -34,6 +34,7 @@ class _StataModelBase(Timestamp):
     id = db.Column(db.String(100), primary_key=True)
     source_id = db.Column(db.String(100))
     index = db.Column(db.String(100), nullable=False)
+    type = db.Column(db.String(50), nullable=False)
     source = db.Column(
         db.JSON()
         .with_variant(postgresql.JSONB(none_as_null=True), "postgresql",)

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -83,7 +83,7 @@ class _StataModelBase(Timestamp):
     @classmethod
     def get_by_event_type(
         cls, _index: str, event_type, start_date: datetime = None, end_date: datetime = None
-    ) -> List:
+    ):
         """
         Get stats data by event type, supporting both old and new versions of data.
         :param _index: event index for filtering.

--- a/modules/invenio-stats/invenio_stats/models.py
+++ b/modules/invenio-stats/invenio_stats/models.py
@@ -82,7 +82,7 @@ class _StataModelBase(Timestamp):
     
     @classmethod
     def get_by_event_type(
-        cls, _index: str, event_type, start_date: datetime = None, end_date: datetime = None
+        cls, _index, event_type, start_date = None, end_date = None
     ):
         """
         Get stats data by event type, supporting both old and new versions of data.
@@ -92,7 +92,7 @@ class _StataModelBase(Timestamp):
         :param end_date: end date for filtering.
         :return: List of filtered data.
         """
-        from sqlalchemy import func,or_
+        from sqlalchemy import func, or_, and_
         
         # _index = 'tenant1-stats-index'/'tenant1-stats-events-index'
         # beforeindex = 'tenant1-stats-[event-type]'/'tenant1-events-stats-[event-type]'

--- a/modules/invenio-stats/invenio_stats/utils.py
+++ b/modules/invenio-stats/invenio_stats/utils.py
@@ -1368,9 +1368,14 @@ class StatsCliUtil:
         self.__cli_restore_es_data_from_db(modified_data)
         
     def __modify_restore_data(self, data):
-        """Modify restore data to meet the new requirements.
-        :param data: Original restore data from DB.
-        :return: Modified data generator.
+        """
+        Modify restore data to meet the new requirements.
+
+        Args:
+            data (dict): Original restore data from the database.
+
+        Returns:
+            generator: Modified data generator.
         """
         search_index_prefix = current_app.config["SEARCH_INDEX_PREFIX"].strip("-")
         stats_index = search_index_prefix + "-stats-index"

--- a/modules/invenio-stats/invenio_stats/utils.py
+++ b/modules/invenio-stats/invenio_stats/utils.py
@@ -1393,11 +1393,11 @@ class StatsCliUtil:
             if not event_type:
                 if self.cli_type==self.EVENTS_TYPE:
                     # tenant1-events-stats-file-download
-                    event_type = "-".join(index.split("-")[3:])
+                    event_type = index.replace(search_index_prefix + "-stats-", "")
                     doc["_index"] = event_stats_index
                 elif self.cli_type==self.AGGREGATIONS_TYPE:
                     # tenant1-stats-file-download
-                    event_type = "-".join(index.split("-")[2:])
+                    event_type = index.replace(search_index_prefix + "-events-stats-", "")
                     doc["_index"] = stats_index
                 if event_type in {"file-download", "file-preview"}:
                     doc["_id"] = f"{doc['_id']}-{event_type}"

--- a/modules/invenio-stats/invenio_stats/utils.py
+++ b/modules/invenio-stats/invenio_stats/utils.py
@@ -1367,7 +1367,7 @@ class StatsCliUtil:
         modified_data = self.__modify_restore_data(data)    
         self.__cli_restore_es_data_from_db(modified_data)
         
-    def __modify_restore_data(self, data) -> Generator:
+    def __modify_restore_data(self, data):
         """Modify restore data to meet the new requirements.
         :param data: Original restore data from DB.
         :return: Modified data generator.

--- a/modules/invenio-stats/invenio_stats/utils.py
+++ b/modules/invenio-stats/invenio_stats/utils.py
@@ -1367,7 +1367,7 @@ class StatsCliUtil:
         modified_data = self.__modify_restore_data(data)    
         self.__cli_restore_es_data_from_db(modified_data)
         
-    def __modify_restore_data(self, data: Generator) -> Generator:
+    def __modify_restore_data(self, data) -> Generator:
         """Modify restore data to meet the new requirements.
         :param data: Original restore data from DB.
         :return: Modified data generator.
@@ -1391,11 +1391,11 @@ class StatsCliUtil:
             
             event_type = document.get("event_type", None)
             if not event_type:
-                if self.cli_type==0:
+                if self.cli_type==self.EVENTS_TYPE:
                     # tenant1-events-stats-file-download
                     event_type = "-".join(index.split("-")[3:])
                     doc["_index"] = event_stats_index
-                elif self.cli_type==1:
+                elif self.cli_type==self.AGGREGATIONS_TYPE:
                     # tenant1-stats-file-download
                     event_type = "-".join(index.split("-")[2:])
                     doc["_index"] = stats_index

--- a/modules/invenio-stats/invenio_stats/utils.py
+++ b/modules/invenio-stats/invenio_stats/utils.py
@@ -1393,11 +1393,11 @@ class StatsCliUtil:
             if not event_type:
                 if self.cli_type==self.EVENTS_TYPE:
                     # tenant1-events-stats-file-download
-                    event_type = index.replace(search_index_prefix + "-stats-", "")
+                    event_type = index.replace(search_index_prefix + "-events-stats-", "")
                     doc["_index"] = event_stats_index
                 elif self.cli_type==self.AGGREGATIONS_TYPE:
                     # tenant1-stats-file-download
-                    event_type = index.replace(search_index_prefix + "-events-stats-", "")
+                    event_type = index.replace(search_index_prefix + "-stats-", "")
                     doc["_index"] = stats_index
                 if event_type in {"file-download", "file-preview"}:
                     doc["_id"] = f"{doc['_id']}-{event_type}"

--- a/modules/invenio-stats/invenio_stats/utils.py
+++ b/modules/invenio-stats/invenio_stats/utils.py
@@ -1421,7 +1421,6 @@ class StatsCliUtil:
             if not _type:
                 continue
             prefix = "stats-index"
-            search_type = prefix.format(_type)
 
             if self.index_prefix:
                 _index = f"{search_index_prefix}-{self.index_prefix}-{prefix}"

--- a/modules/invenio-stats/tests/conftest.py
+++ b/modules/invenio-stats/tests/conftest.py
@@ -538,31 +538,6 @@ def es(app):
             body=aggr_item_create_mapping
         )
 
-        event_list = ('celery-task', 'item-create', 'top-view',
-                      'record-view', 'file-download', 'file-preview', 'search')
-        for event_name in event_list:
-            current_search_client.indices.put_alias(
-                index="{}events-stats-index".format(
-                    app.config['SEARCH_INDEX_PREFIX']),
-                name="{}events-stats-{}".format(
-                    app.config['SEARCH_INDEX_PREFIX'], event_name),
-                body={
-                    "is_write_index": True,
-                    "filter": {"term": {"event_type": event_name}}
-                }
-            )
-
-            current_search_client.indices.put_alias(
-                index="{}stats-index".format(
-                    app.config['SEARCH_INDEX_PREFIX']),
-                name="{}stats-{}".format(
-                    app.config['SEARCH_INDEX_PREFIX'], event_name),
-                body={
-                    "is_write_index": True,
-                    "filter": {"term": {"event_type": event_name}}
-                }
-            )
-
         try:
             yield current_search_client
         finally:

--- a/modules/invenio-stats/tests/test_cli.py
+++ b/modules/invenio-stats/tests/test_cli.py
@@ -119,12 +119,20 @@ def test_events_restore(app, script_info, es, db, event_queues):
     import json
     import time
 
-    # 以下のSQLを先に実行する必要がある
-    # CREATE TABLE stats_events_2024_12_31 PARTITION OF stats_events
-    # FOR VALUES FROM ('2020-01-01 00:00:00') TO ('2024-12-31 00:00:00');
-
     with app.app_context():
         runner = CliRunner()
+        
+        # 以下のSQLを先に実行する必要がある
+        # CREATE TABLE stats_events_2024_12_31 PARTITION OF stats_events
+        # FOR VALUES FROM ('2020-01-01 00:00:00') TO ('2024-12-31 00:00:00');
+
+        sql = """
+            CREATE TABLE stats_events_2024_12_31 PARTITION OF stats_events
+            FOR VALUES FROM ('2020-01-01 00:00:00') TO ('2024-12-31 00:00:00');
+        """
+        with db.engine.connect() as connection:
+            connection.execute(str(sql))
+            print("Partation table created successfully.")
 
         new_version_data = [
             {
@@ -151,7 +159,7 @@ def test_events_restore(app, script_info, es, db, event_queues):
                 "updated": "2024-09-13 09:36:45.524261",
                 "_id": "2024-09-13T09:36:30-b26d305f1c7d2bc280e50df53fe9bd548b9b4251",
                 "_index": "test-events-stats-top-view",
-                # "type": "stats-top-view", バージョンアップにより削除された
+                "type": "stats-top-view",
                 "timestamp": "2024-09-13T09:36:31",
                 "_source": "{\"timestamp\": \"2024-09-13T09:36:31\", \"unique_id\": \"a3a4c4e0-032e-3d08-beee-b4f79681e21c\", \"remote_addr\": \"192.168.56.1\", \"visitor_id\": \"a2c4a00903fce259a64795b27087a6afa7921e8927facdd3011602d9\"}",
                 "date": datetime.strptime("2024-09-13 09:36:31", "%Y-%m-%d %H:%M:%S")
@@ -161,7 +169,7 @@ def test_events_restore(app, script_info, es, db, event_queues):
                 "updated": "2024-11-15 07:01:06.441358",
                 "_id": "2024-11-15T07:00:00-840dab21ad2035be553bce285cca8108154dfb62",
                 "_index": "test-events-stats-file-download",
-                # "type": "stats-file-download", バージョンアップにより削除された
+                "type": "stats-file-download",
                 "timestamp": "2024-11-15T07:00:17",
                 "_source": "{\"timestamp\": \"2024-11-15T07:00:17\", \"unique_id\": \"0327ab05-39cc-38da-8dcf-ed4e26f6eaef\", \"remote_addr\": \"192.168.56.1\", \"visitor_id\": \"66aad2366fc18433f2c279affa6771e8cee2c63aaa0604e163e51901\", \"file_id\": \"55641917-719f-4068-96e8-3f9178fce963\", \"item_id\": \"2000005\", \"file_key\": \"data.zip\"}",
                 "date": datetime.strptime("2024-11-15 07:00:17", "%Y-%m-%d %H:%M:%S")

--- a/modules/invenio-stats/tests/test_cli.py
+++ b/modules/invenio-stats/tests/test_cli.py
@@ -226,7 +226,7 @@ def test_events_restore(app, script_info, es, db, event_queues):
 
         for i, case in enumerate(test_cases):
             cmd = ["events", "restore"] + case["params"] + ["--force", "--verbose"]
-            result = runner.invoke(stats, cmd, obj=script_info)
+            runner.invoke(stats, cmd, obj=script_info)
 
             time.sleep(15)
 
@@ -244,8 +244,14 @@ def test_events_restore(app, script_info, es, db, event_queues):
             delete_cmd = ["events", "delete", "--force", "--verbose", "--yes-i-know"]
             runner.invoke(stats, delete_cmd, obj=script_info)
             
-            print(f"Test progress: {i+1}/4")
             time.sleep(5)
+            
+            # delete結果検証
+            query_1 = dsl.Search(using=es, index="test-events-stats-index")
+            res_1 = query_1.execute()
+            assert res_1.hits.total.value == 0
+            
+            print(f"Test progress: {i+1}/4")
 
 # def _aggregations_process(aggregation_types=None, start_date=None, end_date=None, update_bookmark=False, eager=False):
 # .tox/c1/bin/pytest --cov=invenio_stats tests/test_cli.py::test_aggregations_process -v -s -vv --cov-branch --cov-report=term --cov-config=tox.ini --basetemp=/code/modules/invenio-stats/.tox/c1/tmp

--- a/modules/invenio-stats/tests/test_cli.py
+++ b/modules/invenio-stats/tests/test_cli.py
@@ -112,6 +112,132 @@ def test_events_delete_restore(app, script_info, es, event_queues):
         obj=script_info)
     assert result
 
+# .tox/c1/bin/pytest --cov=invenio_stats tests/test_cli.py::test_events_restore -v -s -vv --cov-branch --cov-report=term --cov-config=tox.ini --basetemp=/code/modules/invenio-stats/.tox/c1/tmp
+def test_events_restore(app, script_info, es, db, event_queues):
+    from invenio_stats.models import StatsEvents
+    from datetime import datetime
+    import json
+    import time
+
+    # 以下のSQLを先に実行する必要がある
+    # CREATE TABLE stats_events_2024_12_31 PARTITION OF stats_events
+    # FOR VALUES FROM ('2020-01-01 00:00:00') TO ('2024-12-31 00:00:00');
+
+    with app.app_context():
+        runner = CliRunner()
+
+        new_version_data = [
+            {
+                "created": "2024-11-28 00:33:09.480608",
+                "updated": "2024-11-28 00:33:09.480612",
+                "_id": "2024-11-28T00:32:30-1277b9fdc34f218e8e1802f30523832c6d0ec86f",
+                "_index": "test-events-stats-index",
+                "_source":{"event_type":"top-view","timestamp":"2024-11-28T00:32:41","unique_id":"d24421df-bc17-3b86-a180-897a9882e667","remote_addr":"192.168.56.1","visitor_id":"48dab7ebc3f8363a70e420ceaec7bc1a6c56c5d5a2fe9c9c1f55da39"},
+                "date": datetime.strptime("2024-11-28 00:32:41", "%Y-%m-%d %H:%M:%S")
+            },
+            {
+                "created": "2024-11-28 00:35:09.389215",
+                "updated": "2024-11-28 00:35:09.389219",
+                "_id": "2024-11-28T00:34:00-898cf618a0bcadc7eab07ac2a453d705ba92cd78",
+                "_index": "test-events-stats-index",
+                "_source":{"event_type":"file-download","timestamp":"2024-11-28T00:34:12","unique_id":"f8aaa533-bdbd-360c-aaef-39455dabb40e","remote_addr":"192.168.56.1","visitor_id":"48dab7ebc3f8363a70e420ceaec7bc1a6c56c5d5a2fe9c9c1f55da39","file_id":"3f642f8b-433a-447e-9bdd-cf5d867788c4","item_id":"5","file_key":"Test_video.mp4"},
+                "date": datetime.strptime("2024-11-28 00:34:12", "%Y-%m-%d %H:%M:%S")
+            }
+        ]
+
+        old_version_data = [
+            {
+                "created": "2024-09-13 09:36:45.524256",
+                "updated": "2024-09-13 09:36:45.524261",
+                "_id": "2024-09-13T09:36:30-b26d305f1c7d2bc280e50df53fe9bd548b9b4251",
+                "_index": "test-events-stats-top-view",
+                # "type": "stats-top-view", バージョンアップにより削除された
+                "timestamp": "2024-09-13T09:36:31",
+                "_source": "{\"timestamp\": \"2024-09-13T09:36:31\", \"unique_id\": \"a3a4c4e0-032e-3d08-beee-b4f79681e21c\", \"remote_addr\": \"192.168.56.1\", \"visitor_id\": \"a2c4a00903fce259a64795b27087a6afa7921e8927facdd3011602d9\"}",
+                "date": datetime.strptime("2024-09-13 09:36:31", "%Y-%m-%d %H:%M:%S")
+            },
+            {
+                "created": "2024-11-15 07:01:06.441355",
+                "updated": "2024-11-15 07:01:06.441358",
+                "_id": "2024-11-15T07:00:00-840dab21ad2035be553bce285cca8108154dfb62",
+                "_index": "test-events-stats-file-download",
+                # "type": "stats-file-download", バージョンアップにより削除された
+                "timestamp": "2024-11-15T07:00:17",
+                "_source": "{\"timestamp\": \"2024-11-15T07:00:17\", \"unique_id\": \"0327ab05-39cc-38da-8dcf-ed4e26f6eaef\", \"remote_addr\": \"192.168.56.1\", \"visitor_id\": \"66aad2366fc18433f2c279affa6771e8cee2c63aaa0604e163e51901\", \"file_id\": \"55641917-719f-4068-96e8-3f9178fce963\", \"item_id\": \"2000005\", \"file_key\": \"data.zip\"}",
+                "date": datetime.strptime("2024-11-15 07:00:17", "%Y-%m-%d %H:%M:%S")
+            }
+        ]
+
+        db.create_all()
+        test_data = new_version_data + old_version_data
+        for data in test_data:
+            if isinstance(data["_source"], str):
+                data["_source"]=json.loads(data["_source"])
+            StatsEvents.save(data, True)
+
+        time.sleep(3)
+
+        test_cases = [
+            # date
+            {
+                "params": ["--start-date=2024-11-01", "--end-date=2024-11-30"],
+                "expected_ids": [
+                    "2024-11-28T00:32:30-1277b9fdc34f218e8e1802f30523832c6d0ec86f",
+                    "2024-11-28T00:34:00-898cf618a0bcadc7eab07ac2a453d705ba92cd78",
+                    "2024-11-15T07:00:00-840dab21ad2035be553bce285cca8108154dfb62-file-download"
+                ]
+            },
+            # single event-type
+            {
+                "params": ["top-view"],
+                "expected_ids": [
+                    "2024-11-28T00:32:30-1277b9fdc34f218e8e1802f30523832c6d0ec86f",
+                    "2024-09-13T09:36:30-b26d305f1c7d2bc280e50df53fe9bd548b9b4251"
+                ]
+            },
+            # double event-type
+            {
+                "params": ["top-view", "file-download"],
+                "expected_ids": [
+                    "2024-11-28T00:32:30-1277b9fdc34f218e8e1802f30523832c6d0ec86f",
+                    "2024-11-28T00:34:00-898cf618a0bcadc7eab07ac2a453d705ba92cd78",
+                    "2024-11-15T07:00:00-840dab21ad2035be553bce285cca8108154dfb62-file-download",
+                    "2024-09-13T09:36:30-b26d305f1c7d2bc280e50df53fe9bd548b9b4251"
+                ]
+            },
+            # date + event-type
+            {
+                "params": ["file-download", "top-view", "--start-date=2024-11-01", "--end-date=2024-11-30"],
+                "expected_ids": [
+                    "2024-11-28T00:32:30-1277b9fdc34f218e8e1802f30523832c6d0ec86f",
+                    "2024-11-28T00:34:00-898cf618a0bcadc7eab07ac2a453d705ba92cd78",
+                    "2024-11-15T07:00:00-840dab21ad2035be553bce285cca8108154dfb62-file-download"
+                ]
+            }
+        ]
+
+        for i, case in enumerate(test_cases):
+            cmd = ["events", "restore"] + case["params"] + ["--force", "--verbose"]
+            result = runner.invoke(stats, cmd, obj=script_info)
+
+            time.sleep(15)
+
+            query = dsl.Search(using=es, index="test-events-stats-index")
+            res = query.execute()
+
+            restored_ids = [hit.meta.id for hit in res]
+            assert set(restored_ids) == set(case["expected_ids"])
+
+            for hit in res:
+                assert "event_type" in hit.to_dict()
+                if hit.meta.id in [id for id in case['expected_ids'] if id.endswith("-file-download")]:
+                    assert hit.to_dict()["unique_id"].endswith("-file-download")
+
+            delete_cmd = ["events", "delete", "--force", "--verbose", "--yes-i-know"]
+            runner.invoke(stats, delete_cmd, obj=script_info)
+            
+            print(f"Test progress: {i+1}/4")
+            time.sleep(5)
 
 # def _aggregations_process(aggregation_types=None, start_date=None, end_date=None, update_bookmark=False, eager=False):
 # .tox/c1/bin/pytest --cov=invenio_stats tests/test_cli.py::test_aggregations_process -v -s -vv --cov-branch --cov-report=term --cov-config=tox.ini --basetemp=/code/modules/invenio-stats/.tox/c1/tmp

--- a/modules/invenio-stats/tests/test_cli.py
+++ b/modules/invenio-stats/tests/test_cli.py
@@ -176,7 +176,6 @@ def test_events_restore(app, script_info, es, db, event_queues):
             }
         ]
 
-        db.create_all()
         test_data = new_version_data + old_version_data
         for data in test_data:
             if isinstance(data["_source"], str):

--- a/modules/invenio-stats/tests/test_models.py
+++ b/modules/invenio-stats/tests/test_models.py
@@ -40,8 +40,105 @@ def test_StatsEvents(app, db, stats_events_for_db):
         assert StatsEvents.save(_save_data2) == True
     with patch('invenio_db.db.session.execute', side_effect=SQLAlchemyError("test_sql_error")):
         assert StatsEvents.save(_save_data1) == False
+      
+# .tox/c1/bin/pytest --cov=invenio_stats tests/test_models.py::test_get_by_event_type -v -s -vv --cov-branch --cov-report=term --cov-config=tox.ini --basetemp=/code/modules/invenio-stats/.tox/c1/tmp        
+def test_get_by_event_type(app, db):
+    from invenio_stats.models import StatsEvents
+    from datetime import datetime
+    import json
+    import time
+    from click.testing import CliRunner
 
+    with app.app_context():
+        runner = CliRunner()
+        
+        # CREATE TABLE stats_events_2024_12_31 PARTITION OF stats_events
+        # FOR VALUES FROM ('2020-01-01 00:00:00') TO ('2024-12-31 00:00:00');
 
+        sql = """
+            CREATE TABLE stats_events_2024_12_31 PARTITION OF stats_events
+            FOR VALUES FROM ('2020-01-01 00:00:00') TO ('2024-12-31 00:00:00');
+        """
+        with db.engine.connect() as connection:
+            connection.execute(str(sql))
+            print("Partation table created successfully.")
+
+        new_version_data = [
+            {
+                "created": "2024-11-28 00:33:09.480608",
+                "updated": "2024-11-28 00:33:09.480612",
+                "_id": "2024-11-28T00:32:30-1277b9fdc34f218e8e1802f30523832c6d0ec86f",
+                "_index": "test-events-stats-index",
+                "_source":{"event_type":"top-view","timestamp":"2024-11-28T00:32:41","unique_id":"d24421df-bc17-3b86-a180-897a9882e667","remote_addr":"192.168.56.1","visitor_id":"48dab7ebc3f8363a70e420ceaec7bc1a6c56c5d5a2fe9c9c1f55da39"},
+                "date": datetime.strptime("2024-11-28 00:32:41", "%Y-%m-%d %H:%M:%S")
+            },
+            {
+                "created": "2024-11-28 00:35:09.389215",
+                "updated": "2024-11-28 00:35:09.389219",
+                "_id": "2024-11-28T00:34:00-898cf618a0bcadc7eab07ac2a453d705ba92cd78",
+                "_index": "test-events-stats-index",
+                "_source":{"event_type":"file-download","timestamp":"2024-11-28T00:34:12","unique_id":"f8aaa533-bdbd-360c-aaef-39455dabb40e","remote_addr":"192.168.56.1","visitor_id":"48dab7ebc3f8363a70e420ceaec7bc1a6c56c5d5a2fe9c9c1f55da39","file_id":"3f642f8b-433a-447e-9bdd-cf5d867788c4","item_id":"5","file_key":"Test_video.mp4"},
+                "date": datetime.strptime("2024-11-28 00:34:12", "%Y-%m-%d %H:%M:%S")
+            }
+        ]
+
+        old_version_data = [
+            {
+                "created": "2024-09-13 09:36:45.524256",
+                "updated": "2024-09-13 09:36:45.524261",
+                "_id": "2024-09-13T09:36:30-b26d305f1c7d2bc280e50df53fe9bd548b9b4251",
+                "_index": "test-events-stats-top-view",
+                "type": "stats-top-view",
+                "timestamp": "2024-09-13T09:36:31",
+                "_source": "{\"timestamp\": \"2024-09-13T09:36:31\", \"unique_id\": \"a3a4c4e0-032e-3d08-beee-b4f79681e21c\", \"remote_addr\": \"192.168.56.1\", \"visitor_id\": \"a2c4a00903fce259a64795b27087a6afa7921e8927facdd3011602d9\"}",
+                "date": datetime.strptime("2024-09-13 09:36:31", "%Y-%m-%d %H:%M:%S")
+            },
+            {
+                "created": "2024-11-15 07:01:06.441355",
+                "updated": "2024-11-15 07:01:06.441358",
+                "_id": "2024-11-15T07:00:00-840dab21ad2035be553bce285cca8108154dfb62",
+                "_index": "test-events-stats-file-download",
+                "type": "stats-file-download",
+                "timestamp": "2024-11-15T07:00:17",
+                "_source": "{\"timestamp\": \"2024-11-15T07:00:17\", \"unique_id\": \"0327ab05-39cc-38da-8dcf-ed4e26f6eaef\", \"remote_addr\": \"192.168.56.1\", \"visitor_id\": \"66aad2366fc18433f2c279affa6771e8cee2c63aaa0604e163e51901\", \"file_id\": \"55641917-719f-4068-96e8-3f9178fce963\", \"item_id\": \"2000005\", \"file_key\": \"data.zip\"}",
+                "date": datetime.strptime("2024-11-15 07:00:17", "%Y-%m-%d %H:%M:%S")
+            }
+        ]
+
+        test_data = new_version_data + old_version_data
+        for data in test_data:
+            if isinstance(data["_source"], str):
+                data["_source"]=json.loads(data["_source"])
+            StatsEvents.save(data, True)
+            
+        # type & date 1
+        index = "test-events-stats-index"
+        type = "file-download"
+        start_date = "2024-11-01"
+        end_date = "2024-11-30"
+        data = StatsEvents.get_by_event_type(index, type, start_date, end_date)
+        assert len(data) == 2
+        
+        # type & date 2
+        index = "test-events-stats-index"
+        type = "top-view"
+        start_date = "2024-11-01"
+        end_date = "2024-11-30"
+        data = StatsEvents.get_by_event_type(index, type, start_date, end_date)
+        assert len(data) == 1
+        
+        # type 1
+        index = "test-events-stats-index"
+        type = "top-view"
+        data = StatsEvents.get_by_event_type(index, type)
+        assert len(data) == 2
+        
+        # type 2
+        index = "test-events-stats-index"
+        type = "file-preview"
+        data = StatsEvents.get_by_event_type(index, type)
+        assert len(data) == 0
+        
 # class StatsAggregation(db.Model, _StataModelBase):
 # .tox/c1/bin/pytest --cov=invenio_stats tests/test_models.py::test_StatsAggregation -v -s -vv --cov-branch --cov-report=term --cov-config=tox.ini --basetemp=/code/modules/invenio-stats/.tox/c1/tmp
 def test_StatsAggregation(app, db):


### PR DESCRIPTION
1. file-download, file-previewのunique_idの生成ロジックの修正
2. reindexツールの修正
3. restore処理の修正
4. 単体テスト作成