### PR TITLE
W2024-23 | Change models  for URL download

### DIFF
--- a/modules/weko-records-ui/weko_records_ui/fd.py
+++ b/modules/weko-records-ui/weko_records_ui/fd.py
@@ -50,11 +50,12 @@ from .models import FileOnetimeDownload, FileSecretDownload, PDFCoverPageSetting
 from .pdf import make_combined_pdf
 from .permissions import check_original_pdf_download_permission, \
     file_permission_factory, is_owners_or_superusers
-from .utils import check_and_send_usage_report, get_billing_file_download_permission, \
-    get_groups_price, get_min_price_billing_file_download, \
-    get_onetime_download, get_secret_download, is_billing_item, parse_one_time_download_token, parse_secret_download_token, \
-    update_onetime_download, update_secret_download, validate_download_record, \
-    validate_onetime_download_token, validate_secret_download_token
+from .utils import (
+    check_and_send_usage_report, get_billing_file_download_permission,
+    get_groups_price, get_min_price_billing_file_download, get_onetime_download,
+    get_secret_download, is_billing_item, parse_one_time_download_token,
+    parse_secret_download_token, validate_download_record,
+    validate_onetime_download_token, validate_secret_download_token)
 
 
 def weko_view_method(pid, record, template=None, **kwargs):
@@ -449,12 +450,6 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
         return render_template(error_template,
                                error="{} does not exist.".format(filename))
 
-    # Create updated data
-    update_data = dict(
-        file_name=filename, record_id=record_id, user_mail=user_mail,
-        download_count=onetime_download.download_count - 1,
-    )
-
     # Check and send usage report for Guest User.
     if onetime_download.extra_info and 'open_restricted' == file_object.get(
             'accessrole'):
@@ -473,12 +468,9 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
             db.session.rollback()
             return render_template(error_template, error=_("Unexpected error occurred."))
 
-        update_data['extra_info'] = extra_info
-
     # Update download data
-    if not update_onetime_download(**update_data):
-        return render_template(error_template,
-                               error=_("Unexpected error occurred."))
+    onetime_download.increment_download_count()
+    onetime_download.update_extra_info(extra_info)
 
     return _download_file(file_object, False, 'en', file_object.obj, pid,
                           record)
@@ -565,16 +557,8 @@ def file_download_secret(pid, record, _record_file_factory=None, **kwargs):
         return render_template(error_template,
                                 error="{} does not exist.".format(filename))
 
-    # Create updated data
-    update_data = dict(
-        file_name=filename, record_id=record_id, id=id,
-        download_count=secret_download.download_count - 1,created=str(date)
-    )
-
     # Update download data
-    if not update_secret_download(**update_data):
-        return render_template(error_template,
-                                error=_("Unexpected error occurred."))
+    secret_download.increment_download_count()
 
     # Get user's language and defautl language for PDF coverpage.
     lang = 'en'

--- a/modules/weko-records-ui/weko_records_ui/fd.py
+++ b/modules/weko-records-ui/weko_records_ui/fd.py
@@ -469,8 +469,10 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
             return render_template(error_template, error=_("Unexpected error occurred."))
 
     # Update download data
-    if (not onetime_download.increment_download_count() or
-        not onetime_download.update_extra_info(extra_info)):
+    try:
+        onetime_download.increment_download_count()
+        onetime_download.update_extra_info(extra_info)
+    except:
         return render_template(error_template,
                                error=_("Unexpected error occurred."))
 
@@ -560,9 +562,11 @@ def file_download_secret(pid, record, _record_file_factory=None, **kwargs):
                                 error="{} does not exist.".format(filename))
 
     # Update download data
-    if not secret_download.increment_download_count():
+    try:
+        secret_download.increment_download_count()
+    except:
         return render_template(error_template,
-                               error=_("Unexpected error occurred"))
+                               error=_("Unexpected error occurred."))
 
     # Get user's language and defautl language for PDF coverpage.
     lang = 'en'

--- a/modules/weko-records-ui/weko_records_ui/fd.py
+++ b/modules/weko-records-ui/weko_records_ui/fd.py
@@ -469,8 +469,10 @@ def file_download_onetime(pid, record, _record_file_factory=None, **kwargs):
             return render_template(error_template, error=_("Unexpected error occurred."))
 
     # Update download data
-    onetime_download.increment_download_count()
-    onetime_download.update_extra_info(extra_info)
+    if (not onetime_download.increment_download_count() or
+        not onetime_download.update_extra_info(extra_info)):
+        return render_template(error_template,
+                               error=_("Unexpected error occurred."))
 
     return _download_file(file_object, False, 'en', file_object.obj, pid,
                           record)
@@ -558,7 +560,9 @@ def file_download_secret(pid, record, _record_file_factory=None, **kwargs):
                                 error="{} does not exist.".format(filename))
 
     # Update download data
-    secret_download.increment_download_count()
+    if not secret_download.increment_download_count():
+        return render_template(error_template,
+                               error=_("Unexpected error occurred"))
 
     # Get user's language and defautl language for PDF coverpage.
     lang = 'en'

--- a/modules/weko-records-ui/weko_records_ui/models.py
+++ b/modules/weko-records-ui/weko_records_ui/models.py
@@ -28,7 +28,7 @@ from typing import List
 
 from flask import current_app
 from invenio_db import db
-from sqlalchemy import desc, or_ ,func
+from sqlalchemy import CheckConstraint, desc, ForeignKey, func
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.sql.functions import concat ,now
@@ -289,66 +289,28 @@ class FilePermission(db.Model):
         db.session.delete(permission)
 
 
-class FileOnetimeDownload(db.Model, Timestamp):
-    """File onetime download."""
+class DownloadMixin:
+    """A mixin class that provides common methods for managing download-related
+    functionality.
 
-    __tablename__ = 'file_onetime_download'
-
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    """Identifier"""
-
-    file_name = db.Column(db.String(255), nullable=False)
-    """File name"""
-
-    user_mail = db.Column(db.String(255), nullable=False)
-    """User mail"""
-
-    record_id = db.Column(db.String(255), nullable=False)
-    """Record identifier."""
-
-    download_count = db.Column(db.Integer, nullable=False, default=0)
-    """Download count"""
-
-    expiration_date = db.Column(db.Integer, nullable=False, default=0)
-    """Expiration Date"""
-
-    extra_info = db.Column(
-        db.JSON().with_variant(
-            postgresql.JSONB(none_as_null=True),
-            'postgresql',
-        ).with_variant(
-            JSONType(),
-            'sqlite',
-        ).with_variant(
-            JSONType(),
-            'mysql',
-        ),
-        default=lambda: dict(),
-        nullable=True
-    )
-    """Extra info."""
-
-    def __init__(self, file_name, user_mail, record_id, download_count=0,
-                 expiration_date=0, extra_info=None):
-        """Init.
-
-        :param file_name: File name
-        :param user_mail: User mail
-        :param record_id: Record identifier
-        :param download_count: Download count
-        :param expiration_date: Expiration date
-        :param extra_info: Extra info want to store
-        """
-        self.file_name = file_name
-        self.user_mail = user_mail
-        self.record_id = record_id
-        self.download_count = download_count
-        self.expiration_date = expiration_date
-        self.extra_info = extra_info
-
+    Note:
+        This mixin class is specifically designed for managing URL-related
+        downloads, particularly one-time URLs and secret URLs.
+    """
     @classmethod
     def create(cls, **data):
-        """Create data."""
+        """Create a new instance and save it to the database.
+        
+        Args:
+            **data: The attributes for the new instance.
+        
+        Returns:
+            object: The created instance, or None if an error occurred.
+
+        Raises:
+            Exception: If the database commit fails, the transaction is rolled
+            back and the exception is re-raised.
+        """
         try:
             file_download = cls(**data)
             db.session.add(file_download)
@@ -358,6 +320,129 @@ class FileOnetimeDownload(db.Model, Timestamp):
             db.session.rollback()
             current_app.logger.error(ex)
             return None
+
+
+    def increment_download_count(self):
+        """Increment the 'download_count' attribute by 1 and commit the change.
+
+        This method increases the download count for the instance by one
+        and persists the change to the database.
+
+        Returns:
+            self: The updated instance with 'download_count' incremented.
+
+        Raises:
+            Exception: If the database commit fails, the transaction is rolled
+            back and the exception is re-raised.
+        """
+        try:
+            self.download_count += 1
+            db.session.commit()
+            return self
+        except Exception as ex:
+            db.session.rollback()
+            current_app.logger.error(ex)
+            raise ex
+
+    def delete_logicaly(self):
+        """Execute logical deletion by setting the 'is_deleted' flag to True.
+
+        This marks the record as deleted without removing it from the database.
+
+        Returns:
+            self: The updated instance with 'is_deleted' set to True.
+
+        Raises:
+            Exception: If the database commit fails, the transaction is rolled
+            back and the exception is re-raised.
+        """
+        try:
+            self.is_deleted = True
+            db.session.commit()
+            return self
+        except Exception as ex:
+            db.session.rollback()
+            current_app.logger.error(ex)
+            raise ex
+
+
+class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
+    """A model class for the 'file_onetime_download' table.
+
+    This class stores information about one-time URLs used for file access.
+
+    Note:
+        Despite being called 'one-time', the download limit can be set to more
+        than once.
+
+    Attributes:
+        id (int): The unique identifier of the record.
+        approver_id (int): The ID of the user who approved the application.
+        record_id (str): The ID of the associated file record.
+        file_name (str): The name of the file.
+        expiration_date (datetime): The date and time when the URL expires.
+        download_limit (int): The maximum number of downloads allowed.
+        download_count (int): The number of times the URL has been downloaded.
+        user_mail (str): The email address of the user who applied.
+        is_guest (bool): Indicates whether the user is a guest.
+        is_deleted (bool): Indicates whether the record is deleted.
+        extra_info (dict): Additional information stored in JSON format.
+    """
+    __tablename__   = 'file_onetime_download'
+    id              = db.Column(db.Integer,primary_key=True,autoincrement=True)
+    creator_id      = db.Column(
+                        db.Integer,
+                        db.ForeignKey(
+                            'accounts_user.id',
+                            name='fk_file_onetime_download_approver_id'),
+                        nullable=False)
+    record_id       = db.Column(db.String(255),nullable=False)
+    file_name       = db.Column(db.String(255), nullable=False)
+    expiration_date = db.Column(db.DateTime, nullable=False)
+    download_limit  = db.Column(db.Integer, nullable=False)
+    download_count  = db.Column(db.Integer, nullable=False, default=0)
+    user_mail       = db.Column(db.String(255), nullable=False)
+    is_guest        = db.Column(db.Boolean, nullable=False, default=False)
+    is_deleted      = db.Column(db.Boolean, nullable=False, default=False)
+    extra_info      = db.Column(db.JSON()
+        .with_variant(postgresql.JSONB(none_as_null=True), 'postgresql')
+        .with_variant(JSONType(), 'sqlite')
+        .with_variant(JSONType(), 'mysql'),
+        default=lambda: dict(),
+        nullable=True,)
+    __table_args__   = (
+        CheckConstraint('created < expiration_date', name='check_expire_date'),
+        CheckConstraint('download_limit > 0', name='check_dl_limit_positive'),
+    )
+
+    def __init__(
+        self, approver_id, record_id, file_name, expiration_date,
+        download_limit, user_mail, is_guest, extra_info
+    ):
+        """Initialize the instance.
+
+        Note:
+            The 'id', 'download_count', and 'is_deleted' fields are not part of
+            the initialization.
+
+        Args:
+            approver_id (int): The ID of the user who approved the application.
+            record_id (str): The ID of the file's associated record.
+            file_name (str): The name of the file.
+            expiration_date (datetime): The date and time when the URL expires.
+            download_limit (int): The download limit of the URL.
+            user_mail (str): The email address of the user who applied.
+            is_guest (bool): A flag indicating whether the user is a guest.
+            extra_info (dict): Additional information stored in JSON format.
+        """
+        self.approver_id     = approver_id
+        self.record_id       = record_id
+        self.file_name       = file_name
+        self.expiration_date = expiration_date
+        self.download_limit  = download_limit
+        self.user_mail       = user_mail
+        self.is_guest        = is_guest
+        self.extra_info      = extra_info
 
     @classmethod
     def update_download(cls, **data):
@@ -418,60 +503,68 @@ class FileOnetimeDownload(db.Model, Timestamp):
             now() < cls.created  + func.cast( concat( cls.expiration_date , ' days' ) , INTERVAL)
         )
         return query.order_by(desc(cls.id)).all()
-        
 
-class FileSecretDownload(db.Model, Timestamp):
-    """File secret download."""
 
+class FileSecretDownload(db.Model, Timestamp, DownloadMixin):
+    """A model class for 'file_secret_download' table.
+
+    This class stores information about secret URLs, which used for private
+    file access.
+
+    Attributes:
+        id (int): The identifier of the record.
+        creator_id (int): The ID of the user who issued the secret URL.
+        record_id (str): The ID of the record that has the file.
+        file_name (str): The name of the file.
+        label_name (str): The label of the secret URL.
+        expiration_date (datetime): The date and time when the URL expires.
+        download_limit (int): The download limit of the URL.
+        download_count (int): The number of times the URL has been downloaded.
+        is_deleted (bool): A flag indicating whether the record is deleted.
+    """
     __tablename__ = 'file_secret_download'
 
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    """Identifier"""
+    id              = db.Column(db.Integer,primary_key=True,autoincrement=True)
+    creator_id      = db.Column(db.Integer,
+                                db.ForeignKey(
+                                    'accounts_user.id',
+                                    name='fk_file_secret_download_creator_id'),
+                                nullable=False)
+    record_id       = db.Column(db.String(255), nullable=False)
+    file_name       = db.Column(db.String(255), nullable=False)
+    label_name      = db.Column(db.String(255), nullable=False)
+    expiration_date = db.Column(db.DateTime, nullable=False)
+    download_limit  = db.Column(db.Integer, nullable=False)
+    download_count  = db.Column(db.Integer, nullable=False, default=0)
+    is_deleted      = db.Column(db.Boolean, nullable=False, default=False)
+    __table_args__  = (
+        CheckConstraint('created < expiration_date', name='check_expire_date'),
+        CheckConstraint('download_limit > 0', name='check_dl_limit_positive'),
+    )
 
-    file_name = db.Column(db.String(255), nullable=False)
-    """File name"""
+    def __init__(self, creator_id, record_id, file_name, label_name,
+                 expiration_date, download_limit):
+        """Initialize the instance.
 
-    user_mail = db.Column(db.String(255), nullable=False)
-    """User mail"""
+        Note:
+            The 'id', 'download_count', and 'is_deleted' fields are not part of
+            the initialization.
 
-    record_id = db.Column(db.String(255), nullable=False)
-    """Record identifier."""
-
-    download_count = db.Column(db.Integer, nullable=False, default=0)
-    """Download count"""
-
-    expiration_date = db.Column(db.Integer, nullable=False, default=0)
-    """Expiration Date"""
-
-    def __init__(self, file_name, user_mail, record_id, download_count=0,
-                 expiration_date=0):
-        """Init.
-
-        :param file_name: File name
-        :param user_mail: User mail
-        :param record_id: Record identifier
-        :param download_count: Download count
-        :param expiration_date: Expiration date
+        Args:
+            creator_id (int): The ID of the user who issued the secret URL.
+            record_id (str): The ID of the record that has the file.
+            file_name (str): The name of the file.
+            label_name (str): The label of the secret URL.
+            expiration_date (datetime): The date and time when the URL expires.
+            download_limit (int): The download limit of the URL.
         """
-        self.file_name = file_name
-        self.user_mail = user_mail
+        self.creator_id = creator_id
         self.record_id = record_id
-        self.download_count = download_count
+        self.file_name = file_name
+        self.label_name = label_name
         self.expiration_date = expiration_date
+        self.download_limit = download_limit
 
-    @classmethod
-    def create(cls, **data):
-        """Create data."""
-        try:
-            file_download = cls(**data)
-            db.session.add(file_download)
-            db.session.commit()
-            db.session.flush()
-            return file_download
-        except Exception as ex:
-            db.session.rollback()
-            current_app.logger.error(ex)
-            raise ex
 
     @classmethod
     def update_download(cls, **data):
@@ -517,5 +610,6 @@ class FileSecretDownload(db.Model, Timestamp):
             cls.created == obj.get("created")
         )
         return query.order_by(desc(cls.id)).all()
+
 
 __all__ = ('PDFCoverPageSettings', 'FilePermission', 'FileOnetimeDownload' ,'FileSecretDownload')

--- a/modules/weko-records-ui/weko_records_ui/models.py
+++ b/modules/weko-records-ui/weko_records_ui/models.py
@@ -310,12 +310,7 @@ class DownloadMixin:
         and persists the change to the database.
 
         Returns:
-            self: The updated instance with 'download_count' incremented.
-
-        Raises:
-            ValueError: If the download count has already reached the limit.
-            Exception: If the database commit fails, the transaction is rolled
-            back and the exception is re-raised.
+            bool: True if the download count is successfully updated
         """
         if self.download_count >= self.download_limit:
             raise ValueError('Download limit has been reached.')
@@ -323,11 +318,11 @@ class DownloadMixin:
             try:
                 self.download_count += 1
                 db.session.commit()
-                return self
+                return True
             except Exception as ex:
                 db.session.rollback()
                 current_app.logger.error(ex)
-                raise ex
+                return False
 
     def delete_logically(self):
         """Execute logical deletion by setting the 'is_deleted' flag to True.
@@ -335,20 +330,16 @@ class DownloadMixin:
         This marks the record as deleted without removing it from the database.
 
         Returns:
-            self: The updated instance with 'is_deleted' set to True.
-
-        Raises:
-            Exception: If the database commit fails, the transaction is rolled
-            back and the exception is re-raised.
+            bool: True if the record is successfully marked as deleted.
         """
         try:
             self.is_deleted = True
             db.session.commit()
-            return self
+            return True
         except Exception as ex:
             db.session.rollback()
             current_app.logger.error(ex)
-            raise ex
+            return False
 
 
 class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
@@ -375,7 +366,7 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
     """
     __tablename__   = 'file_onetime_download'
     id              = db.Column(db.Integer,primary_key=True,autoincrement=True)
-    approver_id      = db.Column(
+    approver_id     = db.Column(
                         db.Integer,
                         db.ForeignKey(
                             'accounts_user.id',
@@ -432,16 +423,12 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
     @classmethod
     def create(cls, **data):
         """Create a new instance and save it to the database.
-        
+
         Args:
             **data: The attributes for the new instance.
-        
+
         Returns:
             FileOnetimeDownload: The created instance, or None if error occurs.
-
-        Raises:
-            Exception: If the database commit fails, the transaction is rolled
-            back and the exception is re-raised.
         """
         try:
             file_download = cls(**data)
@@ -496,7 +483,7 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
             cls.user_mail == obj.get("user_mail"),
         )
         return query.order_by(desc(cls.id)).all()
-    
+
     @classmethod
     def find_downloadable_only(cls, **obj) -> list:
         """If the user can download ,find file onetime download.
@@ -520,11 +507,7 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
             new_info (dict): A dictionary containing the new info to update.
 
         Returns:
-            self: The updated instance with the new 'extra_info'.
-
-        Raises:
-            Exception: If the database commit fails, the transaction is rolled
-            back and the exception is re-raised.
+            bool: True if the update is successful, False otherwise.
         """
         if not isinstance(new_info, dict):
             raise ValueError('The new info must be a dictionary.')
@@ -532,11 +515,11 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
             try:
                 self.extra_info = new_info
                 db.session.commit()
-                return self
+                return True
             except Exception as ex:
                 db.session.rollback()
                 current_app.logger.error(ex)
-                raise ex
+                return False
 
 
 class FileSecretDownload(db.Model, Timestamp, DownloadMixin):
@@ -602,16 +585,12 @@ class FileSecretDownload(db.Model, Timestamp, DownloadMixin):
     @classmethod
     def create(cls, **data):
         """Create a new instance and save it to the database.
-        
+
         Args:
             **data: The attributes for the new instance.
-        
+
         Returns:
             FileSecretDownload: The created instance, or None if error occurs.
-
-        Raises:
-            Exception: If the database commit fails, the transaction is rolled
-            back and the exception is re-raised.
         """
         try:
             file_download = cls(**data)

--- a/modules/weko-records-ui/weko_records_ui/models.py
+++ b/modules/weko-records-ui/weko_records_ui/models.py
@@ -526,14 +526,17 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
             Exception: If the database commit fails, the transaction is rolled
             back and the exception is re-raised.
         """
-        try:
-            self.extra_info = new_info
-            db.session.commit()
-            return self
-        except Exception as ex:
-            db.session.rollback()
-            current_app.logger.error(ex)
-            raise ex
+        if not isinstance(new_info, dict):
+            raise ValueError('The new info must be a dictionary.')
+        else:
+            try:
+                self.extra_info = new_info
+                db.session.commit()
+                return self
+            except Exception as ex:
+                db.session.rollback()
+                current_app.logger.error(ex)
+                raise ex
 
 
 class FileSecretDownload(db.Model, Timestamp, DownloadMixin):

--- a/modules/weko-records-ui/weko_records_ui/models.py
+++ b/modules/weko-records-ui/weko_records_ui/models.py
@@ -527,9 +527,7 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
             back and the exception is re-raised.
         """
         try:
-            if not self.extra_info:
-                self.extra_info = {}
-            self.extra_info.update(new_info)
+            self.extra_info = new_info
             db.session.commit()
             return self
         except Exception as ex:

--- a/modules/weko-records-ui/weko_records_ui/utils.py
+++ b/modules/weko-records-ui/weko_records_ui/utils.py
@@ -1325,15 +1325,6 @@ def create_onetime_download_url(
     return False
 
 
-def update_onetime_download(**kwargs) -> Optional[List[FileOnetimeDownload]]:
-    """Update onetime download.
-
-    @param kwargs:
-    @return:
-    """
-    return FileOnetimeDownload.update_download(**kwargs)
-
-
 def get_workflows():
     """Get workflow.
 
@@ -1928,16 +1919,3 @@ def _create_secret_download_url(file_name: str, record_id: str, user_mail: str) 
         "download_count": download_limit,
     })
     return file_secret
-    
-
-
-def update_secret_download(**kwargs) -> Optional[List[FileSecretDownload]]:
-    """Update secret download.
-
-    Args
-        kwargs:
-    Returns
-        updated List[FileSecretDownload] or None
-    """
-    current_app.logger.debug("update_secret_download:{}".format(kwargs))
-    return FileSecretDownload.update_download(**kwargs)


### PR DESCRIPTION
### 概要

シークレットURLとワンタイムURLのモデル定義の変更

### 詳細

以下の変更を加えました。

- FileSecretDownloadとFileOnetimeDownloadクラスのカラム定義を変更
- CHECK制約を付与
- 削除API用のメソッドを追加
- 両クラスで共通するメソッドをmixinクラスに統合

### ご意見をいただきたい点

- 二つのクラス間で共通する処理が複数あったため、mixinクラスに統合したが問題がないか
- コーディング規約のGoogle Styleに合わせ、docstringを大幅に変更したが問題がないか
- DL回数のカウントアップについて、既存のクラスメソッドではなく新規に作成したインスタンスメソッドを用いる方針だが問題がないか