### PR TITLE
W2024-23 | Add copy endpoint to download URL feature

### DIFF
--- a/modules/weko-records-ui/tests/test_fd.py
+++ b/modules/weko-records-ui/tests/test_fd.py
@@ -261,7 +261,7 @@ def test_add_signals_info(app,records,itemtypes,users):
                     add_signals_info(record,obj)
 
 
-# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_fd.py::test_error_response -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp -p no:warnings
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_fd.py::test_error_response -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 @patch('weko_records_ui.fd.render_template')
 def test_error_response(mock_render):
     mock_render.return_value = '<html>Error Test</html>'
@@ -272,7 +272,7 @@ def test_error_response(mock_render):
     mock_render.assert_called_once_with(error_template, error='Error Test')
 
 
-# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_fd.py::test_file_download_onetime -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp -p no:warnings
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_fd.py::test_file_download_onetime -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 @patch('weko_records_ui.fd.request.args.get')
 @patch('weko_records_ui.fd.validate_url_download')
 @patch('weko_records_ui.fd.error_response')
@@ -402,7 +402,7 @@ def test__is_terms_of_use_only(app, records_restricted, users, db_file_permissio
         with patch("flask_login.utils._get_user", return_value=users[0]["obj"]):
             assert not _is_terms_of_use_only(provide_not,{'terms_of_use_only': True})
 
-# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_fd.py::test_file_download_secret -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp -p no:warnings
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_fd.py::test_file_download_secret -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 @patch('weko_records_ui.fd.request.args.get')
 @patch('weko_records_ui.fd.validate_url_download')
 @patch('weko_records_ui.fd.error_response')

--- a/modules/weko-records-ui/tests/test_views.py
+++ b/modules/weko-records-ui/tests/test_views.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 import uuid
 import pytest
@@ -22,7 +23,9 @@ from weko_workflow.models import (
     FlowDefine,
     WorkFlow,
 )
-from weko_records_ui.models import PDFCoverPageSettings, FilePermission
+from weko_records_ui.models import (
+    FileOnetimeDownload, FileSecretDownload, PDFCoverPageSettings,
+    FilePermission)
 from weko_records_ui.views import (
     check_permission,
     citation,
@@ -52,7 +55,7 @@ from weko_records_ui.views import (
     preview_able,
     get_uri,
 )
-from weko_records_ui.utils import can_manage_secret_url
+from weko_records_ui.utils import create_download_url
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_views.py -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
 
 # def record_from_pid(pid_value):
@@ -548,7 +551,152 @@ def test_default_view_method(app, records, itemtypes, indexstyle, users):
                         index.index_name_english = "index"
                         with patch('weko_records_ui.views.Indexes.get_index', return_value=index):
                             assert default_view_method(recid, record, 'helloworld.pdf').status_code == 200
-                   
+
+
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_views.py::test_create_secret_url_and_send_mail -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
+@patch('weko_records_ui.views.validate_secret_url_generation_request')
+@patch('weko_records_ui.views.can_manage_secret_url')
+@patch('weko_records_ui.utils.current_user')
+@patch('weko_records_ui.views.send_secret_url_mail')
+def test_create_secret_url_and_send_mail(send_mail, login_user, can_manage,
+                                         vldt_req, client, users, records):
+    vldt_req.return_value = True
+    can_manage.return_value = True
+    login_user.id = 1
+    tmp, results = records
+    url = url_for('invenio_records_ui.recid_secret_url',
+           pid_value=results[1]["recid"].pid_value,
+           filename=results[1]["filename"])
+    base_data = {
+        'link_name': '',
+        'expiration_date': '',
+        'download_limit': None,
+        'send_email': False,
+        'timezone_offset_minutes': 0
+    }
+
+    # Success
+    res = client.post(url, data=json.dumps(base_data),
+                      content_type='application/json')
+    assert res.status_code == 200
+    assert 'Secret URL generated successfully' in res.get_data(as_text=True)
+    send_mail.return_value = True
+    data = {**base_data, 'send_email': True}
+    res = client.post(url, data=json.dumps(data),
+                      content_type='application/json')
+    assert res.status_code == 200
+    assert 'Secret URL generated successfully' in res.get_data(as_text=True)
+    assert 'please check your email inbox' in res.get_data(as_text=True)
+    send_mail.return_value = False
+    res = client.post(url, data=json.dumps(data),
+                      content_type='application/json')
+    assert res.status_code == 200
+    assert 'Secret URL generated successfully' in res.get_data(as_text=True)
+    assert 'there was an error' in res.get_data(as_text=True)
+
+    # Fail
+    with patch('weko_records_ui.views.create_secret_url_record',
+               side_effect=Exception('Test DB Error')):
+        with pytest.raises(Exception):
+            res = client.post(url, data=json.dumps(data),
+                            content_type='application/json')
+            assert res.status_code == 500
+    can_manage.return_value = False
+    with pytest.raises(Exception):
+        res = client.post(url, data=json.dumps(data),
+                        content_type='application/json')
+        assert res.status_code == 403
+    vldt_req.return_value = False
+    res = client.post(url, data=json.dumps(data),
+                    content_type='application/json')
+    assert res.status_code == 400
+
+
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_views.py::test_copy_secret_url -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
+def test_copy_secret_url(client, records):
+    _, records = records
+    url = url_for('invenio_records_ui.recid_copy_secret_url',
+                    pid_value=records[1]['recid'].pid_value,
+                    filename=records[1]['filename'],
+                    secret_url_id=1)
+    secret_obj = FileSecretDownload.create(
+        creator_id=1,
+        record_id=records[1]['recid'].pid_value,
+        file_name=records[1]['filename'],
+        label_name='test link',
+        expiration_date=datetime.now(timezone.utc) + timedelta(days=1),
+        download_limit=1,
+    )
+    expected_secret_url = create_download_url(secret_obj)
+    with patch('weko_records_ui.views.can_manage_secret_url',
+                return_value=True):
+        res = client.get(url)
+        assert res.status_code == 200
+        assert ('The secret URL copied to your clipboard.'
+                 in res.get_data(as_text=True))
+        assert res.json['url'] == expected_secret_url
+    with patch('weko_records_ui.views.can_manage_secret_url',
+                return_value=False):
+        with pytest.raises(Exception):
+            res = client.get(url)
+            assert res.status_code == 403
+    with patch('weko_records_ui.views.create_download_url',
+                side_effect=Exception('Test Error')):
+        with pytest.raises(Exception):
+            res = client.get(url)
+            assert res.status_code == 500
+    with patch('weko_records_ui.views.can_manage_secret_url',
+                return_value=True):
+        url = url_for('invenio_records_ui.recid_copy_secret_url',
+                        pid_value=records[1]['recid'].pid_value,
+                        filename=records[1]['filename'],
+                        secret_url_id=99)  # invalid secret_url_id
+        res = client.get(url)
+        assert res.json['url'] is None
+
+# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_views.py::test_copy_onetime_url -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
+def test_copy_onetime_url(client, records):
+    _, records = records
+    url = url_for('invenio_records_ui.recid_copy_onetime_url',
+                    pid_value=records[1]['recid'].pid_value,
+                    filename=records[1]['filename'],
+                    onetime_url_id=1)
+    onetime_obj = FileOnetimeDownload.create(
+        approver_id=1,
+        record_id=records[1]['recid'].pid_value,
+        file_name=records[1]['filename'],
+        expiration_date=datetime.now(timezone.utc) + timedelta(days=1),
+        download_limit=1,
+        user_mail='test@example.org',
+        is_guest=False,
+        extra_info={}
+    )
+    expected_onetime_url = create_download_url(onetime_obj)
+    with patch('weko_records_ui.views.can_manage_onetime_url',
+                return_value=True):
+        res = client.get(url)
+        assert res.status_code == 200
+        assert ('The onetime URL copied to your clipboard.'
+                 in res.get_data(as_text=True))
+        assert res.json['url'] == expected_onetime_url
+    with patch('weko_records_ui.views.can_manage_onetime_url',
+                return_value=False):
+          with pytest.raises(Exception):
+                res = client.get(url)
+                assert res.status_code == 403
+    with patch('weko_records_ui.views.create_download_url',
+                side_effect=Exception('Test Error')):
+          with pytest.raises(Exception):
+                res = client.get(url)
+                assert res.status_code == 500
+    with patch('weko_records_ui.views.can_manage_onetime_url',
+                return_value=True):
+        url = url_for('invenio_records_ui.recid_copy_onetime_url',
+                        pid_value=records[1]['recid'].pid_value,
+                        filename=records[1]['filename'],
+                        onetime_url_id=99)  # invalid onetime_url_id
+        res = client.get(url)
+        assert res.json['url'] is None
 
 
 # def doi_ish_view_method(parent_pid_value=0, version=0):
@@ -989,96 +1137,3 @@ def test_default_view_method_fix35133(app, records, itemtypes, indexstyle,mocker
                         {'name': 'citation_abstract_html_url','data': 'http://TEST_SERVER/records/1'},
                     ]
                 assert kwargs["google_dataset_meta"] == '{"@context": "https://schema.org/", "@type": "Dataset", "citation": ["http://hdl.handle.net/2261/0002005680", "https://repository.dl.itc.u-tokyo.ac.jp/records/2005680"], "creator": [{"@type": "Person", "alternateName": "creator alternative name", "familyName": "creator family name", "givenName": "creator given name", "identifier": "123", "name": "creator name"}], "description": "『史料編纂掛備用寫眞畫像圖畫類目録』（1905年）の「画像」（肖像画模本）の部に著録する資料の架番号の新旧対照表。史料編纂所所蔵肖像画模本データベースおよび『目録』版面画像へのリンク付き。『画像史料解析センター通信』98（2022年10月）に解説記事あり。", "distribution": [{"@type": "DataDownload", "contentUrl": "https://repository.dl.itc.u-tokyo.ac.jp/record/2005680/files/comparison_table_of_preparation_image_catalog.xlsx", "encodingFormat": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}, {"@type": "DataDownload", "contentUrl": "https://raw.githubusercontent.com/RCOSDP/JDCat-base/main/apt.txt", "encodingFormat": "text/plain"}, {"@type": "DataDownload", "contentUrl": "https://raw.githubusercontent.com/RCOSDP/JDCat-base/main/environment.yml", "encodingFormat": "application/x-yaml"}, {"@type": "DataDownload", "contentUrl": "https://raw.githubusercontent.com/RCOSDP/JDCat-base/main/postBuild", "encodingFormat": "text/x-shellscript"}], "includedInDataCatalog": {"@type": "DataCatalog", "name": "https://localhost"}, "license": ["CC BY"], "name": "『史料編纂掛備用写真画像図画類目録』画像の部：新旧架番号対照表", "spatialCoverage": [{"@type": "Place", "geo": {"@type": "GeoCoordinates", "latitude": "point latitude test", "longitude": "point longitude test"}}, {"@type": "Place", "geo": {"@type": "GeoShape", "box": "1 3 2 4"}}, "geo location place test"]}' 
-# def create_secret_url_and_send_mail(pid:PersistentIdentifier, record:WekoRecord, filename:str, **kwargs) -> str:
-# .tox/c1/bin/pytest --cov=weko_records_ui tests/test_views.py::test_create_secret_url_and_send_mail -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp -p no:warnings
-@patch('weko_records_ui.views.validate_secret_url_generation_request')
-@patch('weko_records_ui.views.can_manage_secret_url')
-@patch('weko_records_ui.utils.current_user')
-@patch('weko_records_ui.views.send_secret_url_mail')
-def test_create_secret_url_and_send_mail(send_mail, login_user, can_manage,
-                                         vldt_req, client, users, records):
-    vldt_req.return_value = True
-    can_manage.return_value = True
-    login_user.id = 1
-    tmp, results = records
-    record = results[1]
-    url = url_for('invenio_records_ui.recid_secret_url',
-           pid_value=results[1]["recid"].pid_value,
-           filename=results[1]["filename"])
-    base_data = {
-        'link_name': '',
-        'expiration_date': '',
-        'download_limit': None,
-        'send_email': False,
-        'timezone_offset_minutes': 0
-    }
-
-    # Success
-    res = client.post(url, data=json.dumps(base_data),
-                      content_type='application/json')
-    assert res.status_code == 200
-    assert 'Secret URL generated successfully' in res.get_data(as_text=True)
-    send_mail.return_value = True
-    data = {**base_data, 'send_email': True}
-    res = client.post(url, data=json.dumps(data),
-                      content_type='application/json')
-    assert res.status_code == 200
-    assert 'Secret URL generated successfully' in res.get_data(as_text=True)
-    assert 'please check your email inbox' in res.get_data(as_text=True)
-    send_mail.return_value = False
-    res = client.post(url, data=json.dumps(data),
-                      content_type='application/json')
-    assert res.status_code == 200
-    assert 'Secret URL generated successfully' in res.get_data(as_text=True)
-    assert 'there was an error' in res.get_data(as_text=True)
-
-    # Fail
-    with patch('weko_records_ui.views.create_secret_url_record',
-               side_effect=Exception('Test DB Error')):
-        with pytest.raises(Exception):
-            res = client.post(url, data=json.dumps(data),
-                            content_type='application/json')
-            assert res.status_code == 500
-    can_manage.return_value = False
-    with pytest.raises(Exception):
-        res = client.post(url, data=json.dumps(data),
-                        content_type='application/json')
-        assert res.status_code == 403
-    vldt_req.return_value = False
-    res = client.post(url, data=json.dumps(data),
-                    content_type='application/json')
-    assert res.status_code == 400
-
-
-
-
-# def test_create_secret_url_and_send_mail(app,client,db,users,records):
-#     app.config['WEKO_WORKFLOW_DATE_FORMAT'] = "%Y-%m-%d"
-#     indexer, results = records
-#     record = results[1]
-
-#     # 79
-#     id = 1 #repoadmin
-#     secret_file_url = url_for("invenio_records_ui.recid_secret_url"
-#                                 ,pid_value=results[1]["recid"].pid_value
-#                                 ,filename=results[1]["filename"])
-#     login_user_via_session(client=client, user=users[id]["obj"] ,email=users[id]["email"])
-#     with patch('weko_records_ui.views.can_manage_secret_url',return_value = True):
-#         with patch('weko_records_ui.views.process_send_mail',return_value = True):
-#             # with app.test_request_context():
-#             res = client.get(secret_file_url)
-#             assert res.status_code == 405
-            
-#             res = client.post(secret_file_url ,data=json.dumps({}), content_type='application/json')
-#             assert res.status_code == 200
-#         with patch('weko_records_ui.views.process_send_mail',return_value = False):
-#             with patch("flask.templating._render", return_value=""):
-#                 res = client.post(secret_file_url ,data=json.dumps({}), content_type='application/json')
-#                 assert res.status_code == 500
-#     with patch('weko_records_ui.views.can_manage_secret_url',return_value = False):
-#         with patch('weko_records_ui.views.process_send_mail',return_value = True):
-#             with patch("flask.templating._render", return_value=""):
-#                 res = client.post(secret_file_url ,data=json.dumps({}), content_type='application/json')
-#                 assert res.status_code == 403
-
-# def create_secret_url_and_send_mail(pid:PersistentIdentifier, record:WekoRecord, filename:str, **kwargs) -> str:

--- a/modules/weko-records-ui/weko_records_ui/config.py
+++ b/modules/weko-records-ui/weko_records_ui/config.py
@@ -178,19 +178,29 @@ RECORDS_UI_ENDPOINTS = dict(
                                ':page_permission_factory',
         methods=['POST'],
     ),
+    recid_copy_secret_url=dict(
+        pid_type='recid',
+        route='/records/<pid_value>/secret/<path:filename>/<secret_url_id>',
+        view_imp='weko_records_ui.views.copy_secret_url',
+        record_class='weko_deposit.api:WekoRecord',
+        permission_factory_imp='weko_records_ui.permissions'
+                               ':page_permission_factory',
+        methods=['GET'],
+    ),
+    recid_copy_onetime_url=dict(
+        pid_type='recid',
+        route='/records/<pid_value>/secret/<path:filename>/<onetime_url_id>',
+        view_imp='weko_records_ui.views.copy_onetime_url',
+        record_class='weko_deposit.api:WekoRecord',
+        permission_factory_imp='weko_records_ui.permissions'
+                               ':page_permission_factory',
+        methods=['GET'],
+    ),
     recid_secret_file_download=dict(
         pid_type='recid',
         route='/record/<pid_value>/file/secret/<string:filename>',
         view_imp='weko_records_ui.fd.file_download_secret',
         record_class='weko_deposit.api:WekoRecord',
-    ),
-    recid_copy_url=dict(
-        pid_type='recid',
-        route='/records/<pid_value>/copy_url/<path:filename>/<url_id>',
-        view_imp='weko_records_ui.views.copy_download_url',
-        record_class='weko_deposit.api:WekoRecord',
-        permission_factory_imp='weko_records_ui.permissions'
-                               ':page_permission_factory',
     ),
 )
 

--- a/modules/weko-records-ui/weko_records_ui/config.py
+++ b/modules/weko-records-ui/weko_records_ui/config.py
@@ -184,6 +184,14 @@ RECORDS_UI_ENDPOINTS = dict(
         view_imp='weko_records_ui.fd.file_download_secret',
         record_class='weko_deposit.api:WekoRecord',
     ),
+    recid_copy_url=dict(
+        pid_type='recid',
+        route='/records/<pid_value>/copy_url/<path:filename>/<url_id>',
+        view_imp='weko_records_ui.views.copy_download_url',
+        record_class='weko_deposit.api:WekoRecord',
+        permission_factory_imp='weko_records_ui.permissions'
+                               ':page_permission_factory',
+    ),
 )
 
 WEKO_RECORDS_UI_SECRET_KEY = "secret"

--- a/modules/weko-records-ui/weko_records_ui/config.py
+++ b/modules/weko-records-ui/weko_records_ui/config.py
@@ -189,7 +189,7 @@ RECORDS_UI_ENDPOINTS = dict(
     ),
     recid_copy_onetime_url=dict(
         pid_type='recid',
-        route='/records/<pid_value>/secret/<path:filename>/<onetime_url_id>',
+        route='/records/<pid_value>/onetime/<path:filename>/<onetime_url_id>',
         view_imp='weko_records_ui.views.copy_onetime_url',
         record_class='weko_deposit.api:WekoRecord',
         permission_factory_imp='weko_records_ui.permissions'

--- a/modules/weko-records-ui/weko_records_ui/models.py
+++ b/modules/weko-records-ui/weko_records_ui/models.py
@@ -487,7 +487,7 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
             cls.record_id == obj.get("record_id"),
             cls.user_mail == obj.get("user_mail"),
             cls.download_count < cls.download_limit,
-            cls.expiration_date > datetime.utcnow(),
+            cls.expiration_date > datetime.now(timezone.utc),
             cls.is_deleted == False
         )
         return query.order_by(desc(cls.id)).all()

--- a/modules/weko-records-ui/weko_records_ui/models.py
+++ b/modules/weko-records-ui/weko_records_ui/models.py
@@ -487,7 +487,7 @@ class FileOnetimeDownload(db.Model, Timestamp, DownloadMixin):
             cls.record_id == obj.get("record_id"),
             cls.user_mail == obj.get("user_mail"),
             cls.download_count < cls.download_limit,
-            cls.expiration_date > datetime.now(timezone.utc),
+            cls.expiration_date > datetime.utcnow(),
             cls.is_deleted == False
         )
         return query.order_by(desc(cls.id)).all()

--- a/modules/weko-records-ui/weko_records_ui/utils.py
+++ b/modules/weko-records-ui/weko_records_ui/utils.py
@@ -1299,7 +1299,7 @@ def can_manage_onetime_url(record, filename):
     Returns:
         bool: True if all conditions are met, False otherwise.
     """
-    if not current_user or current_user.is_authenticated:
+    if not current_user or not current_user.is_authenticated:
         return False
     else:
         return (

--- a/modules/weko-records-ui/weko_records_ui/utils.py
+++ b/modules/weko-records-ui/weko_records_ui/utils.py
@@ -1193,6 +1193,11 @@ def has_permission_to_manage_secret_url(record, user_id):
 def has_permission_to_manage_onetime_url(record, user_id):
     """Check if the user has permission to manage a onetime URL.
 
+    The current difference in required permissions between a secret URL and a
+    one-time URL is that users who registered the item on behalf of others do
+    not have permission to manage the one-time URL (though they can manage
+    secret URLs).
+
     Following users have the permission.
     - The administrators.
     - The user who registered the item(record).
@@ -1202,7 +1207,6 @@ def has_permission_to_manage_onetime_url(record, user_id):
     """
     super_roles = current_app.config['WEKO_PERMISSION_SUPER_ROLE_USER']
     user = User.query.filter_by(id=user_id).first()
-    # Need to change the 'weko_shared_id' to 'weko_shared_ids' in the future.
     has_permission = (
         user_id == int(record['owner']) or
         any(role.name in super_roles for role in user.roles or [])


### PR DESCRIPTION
### 概要

シークレットURL・ワンタイムURLのコピー機能のエンドポイントとバックエンド処理を追加

### 詳細

- config.pyにコピー用のエンドポイントを追加
- views.pyにコピー用の関数を追加
- utils.pyにワンタイムURLの編集権限確認メソッドを追加
  - ワンタイムURLのみ、代理投稿者へ権限を付与しない

### その他

ダウンロード履歴の保存の記述を一部修正