### PR TITLE
restrict requestmail api

### DIFF
--- a/modules/weko-admin/weko_admin/static/js/weko_admin/facet_search_admin.js
+++ b/modules/weko-admin/weko_admin/static/js/weko_admin/facet_search_admin.js
@@ -498,7 +498,7 @@ function CustomAggregations({aggregations, setAggregations, mappingList}) {
                     onChange={e => setAggMapping(e.target.value)}>
               {
                 mappingList.map((item) =>
-                  <option key={item[1]} value={item[1]} >{item[1]}</option>)
+                  <option key={item} value={item} >{item}</option>)
               }
             </select>
           </div>

--- a/nginx/weko-ams.conf
+++ b/nginx/weko-ams.conf
@@ -224,6 +224,33 @@ server {
 		#deny all;
 	}
 
+	location ~ /api/v1/(captcha|records/[0-9]*/request-mail) {
+		uwsgi_pass app_server;
+		include uwsgi_params;
+
+		uwsgi_buffering off;
+		uwsgi_request_buffering off;
+
+		uwsgi_buffer_size 32k;
+		uwsgi_buffers 8 32k;
+		uwsgi_busy_buffers_size 32k;
+
+		uwsgi_param Host $host;
+		uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
+		uwsgi_param X-Forwarded-Proto $scheme;
+
+		uwsgi_read_timeout 3600;
+		uwsgi_send_timeout 3600;
+		uwsgi_connect_timeout 60;
+
+		satisfy any;
+		allow 10.0.0.0/8;
+		allow 192.168.0.0/16;
+		allow 172.16.0.0/12;
+		allow 127.0.0.0/8;
+		deny all;
+	}
+
 	location / {
 		proxy_pass http://nuxt;
 		proxy_redirect off;
@@ -309,7 +336,34 @@ server {
 		#deny all;
 	}
 
-	location ~ /record/[0-9]*/file_preview/ {
+	location ~ /record/[0-9]*/(files|file_preview|preview)/ {
+		uwsgi_pass app_server;
+		include uwsgi_params;
+
+		uwsgi_buffering off;
+		uwsgi_request_buffering off;
+		proxy_read_timeout 120;
+		uwsgi_read_timeout 120;
+		# fix 'upstream sent too big header' error
+		uwsgi_buffer_size 32k;
+		uwsgi_buffers 8 32k;
+		uwsgi_busy_buffers_size 32k;
+
+		uwsgi_param Host $host;
+		uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
+		uwsgi_param X-Forwarded-Proto $scheme;
+		uwsgi_hide_header Authorization;
+		client_max_body_size 1024G;
+
+		#satisfy any;
+		#allow 10.0.2.2;
+		#allow 10.0.0.0/8;
+		#allow 192.168.0.0/16;
+		#allow 127.0.0.0/8;
+		#deny all;
+	}
+
+	location /api/iiif/v2/ {
 		uwsgi_pass app_server;
 		include uwsgi_params;
 


### PR DESCRIPTION
・デモ環境用のnginxの設定ファイルでリクエストメールのAPIを使用可能なIPアドレスを制限する
・デモ環境用のnginxの設定ファイルでプレビュー機能が使えない不具合を修正
・admin画面のファセット検索設定画面の不具合を修正