### PR TITLE
invenio-communitiesのalembicの整理

### DIFF
--- a/modules/invenio-communities/invenio_communities/alembic/1b352b00f1ed_add_columns.py
+++ b/modules/invenio-communities/invenio_communities/alembic/1b352b00f1ed_add_columns.py
@@ -13,15 +13,15 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1b352b00f1ed'
-down_revision = '2d9884d0e3fa'
+down_revision = 'd2d56dc5e385'
 branch_labels = ()
 depends_on = None
 
 
 def upgrade():
     """Upgrade database."""
-    op.add_column('communities_community', sa.Column('content_policy', sa.Text(), nullable=False))
-    op.add_column('communities_community', sa.Column('group_id', sa.Integer(), nullable=False))
+    op.add_column('communities_community', sa.Column('content_policy', sa.Text(), nullable=True))
+    op.add_column('communities_community', sa.Column('group_id', sa.Integer(), nullable=True))
     op.create_foreign_key(op.f('fk_communities_community_group_id_accounts_role'), 'communities_community', 'accounts_role', ['group_id'], ['id'])
 
 

--- a/modules/invenio-communities/invenio_communities/models.py
+++ b/modules/invenio-communities/invenio_communities/models.py
@@ -254,13 +254,13 @@ class Community(db.Model, Timestamp):
     )
     """Id of Root Node"""
     
-    content_policy = db.Column(db.Text, nullable=False, default='')
+    content_policy = db.Column(db.Text, nullable=True, default='')
     """Community content policy."""
     
     group_id = db.Column(
         db.Integer,
         db.ForeignKey(Role.id),
-        nullable=False
+        nullable=True
     )
     """Group of the community."""
 


### PR DESCRIPTION
### 説明
invenio-communities に alembic を追加した影響で、既存のマイグレーションと競合が発生し、
両方の修正を適用できない状態になっていました。
本PRでは、down_revision を適切に修正し、マイグレーションの適用順序を正しくしました。

### 確認項目
- [x] alembic upgrade head が正常に適用できること
- [x] 変更後のスキーマが想定通りであること