### PR TITLE
repository_id に server_default を追加

### DIFF
--- a/modules/weko-admin/weko_admin/alembic/030be6fdaa51_add_server_deafult_to_repository_id.py
+++ b/modules/weko-admin/weko_admin/alembic/030be6fdaa51_add_server_deafult_to_repository_id.py
@@ -1,0 +1,45 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Add server_deafult to repository_id"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '030be6fdaa51'
+down_revision = '7dc0b1ab5631'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.alter_column('feedback_email_setting', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default='Root Index')
+    op.alter_column('feedback_mail_history', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default='Root Index')
+    op.alter_column('stats_email_address', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default='Root Index')
+
+
+def downgrade():
+    """Downgrade database."""
+    op.alter_column('feedback_email_setting', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default=None)
+    op.alter_column('feedback_mail_history', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default=None)
+    op.alter_column('stats_email_address', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default=None)
+

--- a/modules/weko-records/weko_records/alembic/4d2556236060_add_server_deafult_to_repository_id.py
+++ b/modules/weko-records/weko_records/alembic/4d2556236060_add_server_deafult_to_repository_id.py
@@ -1,0 +1,38 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Add server_deafult to repository_id"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4d2556236060'
+down_revision = '1619a115156f'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.alter_column('feedback_mail_list', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default='Root Index')
+    op.alter_column('sitelicense_info', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default='Root Index')
+
+
+def downgrade():
+    """Downgrade database."""
+    op.alter_column('feedback_mail_list', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default=None)
+    op.alter_column('sitelicense_info', 'repository_id',
+                    existing_type=sa.String(length=100),
+                    server_default=None)


### PR DESCRIPTION
### 説明
このプルリクエストでは、以下の変更を行いました：
- repository_id カラムに server_default を追加

  - サブリポジトリ管理機能で追加したカラムの"repository_id"にserver_defaultを追加するマイグレーションスクリプトを追加しました。
  - これにより、既存データには'Root Index'が設定されるようになりました。
  
### 変更内容
- feedback_email_setting テーブルの repository_id カラムに server_default を追加。
- feedback_mail_history テーブルの repository_id カラムに server_default を追加。
- stats_email_address テーブルの repository_id カラムに server_default を追加。
- feedback_mail_list テーブルの repository_id カラムに server_default を追加。
- sitelicense_info テーブルの repository_id カラムに server_default を追加。

### テスト：
データベースマイグレーションを実行した後、各テーブルで repository_id に対してデフォルト値が正しく設定されることを確認しました。

ご確認のほど、よろしくお願い致します。