### PR TITLE
ユーザ管理画面修正

### DIFF
--- a/modules/invenio-accounts/invenio_accounts/admin.py
+++ b/modules/invenio-accounts/invenio_accounts/admin.py
@@ -98,15 +98,26 @@ class UserView(ModelView):
             get_label='name',
             widget=Select2Widget(multiple=True)
         )
+        
         return form_class
     
-    def on_form_prefill(self, form, id):
+    def _order_fields(self, form):
         custom_order = ['email', 'password', 'active', 'roles','groups', 'notification']
         ordered_fields = OrderedDict()
         for field_name in custom_order:
             ordered_fields[field_name] = form._fields[field_name]
         form._fields = ordered_fields
-        
+        return form
+    
+    def create_form(self, obj=None):
+        form = super(UserView, self).create_form(obj)
+        return self._order_fields(form)
+    
+    def edit_form(self, obj=None):
+        form = super(UserView, self).edit_form(obj)
+        return self._order_fields(form)
+
+    def on_form_prefill(self, form, id):
         obj = self.get_one(id)
         form.roles.data = [role for role in obj.roles if '_groups_' not in role.name]
         form.groups.data = [role for role in obj.roles if '_groups_' in role.name]

--- a/modules/invenio-accounts/tests/test_admin.py
+++ b/modules/invenio-accounts/tests/test_admin.py
@@ -276,3 +276,10 @@ def test_userview_on_form_prefill(app, users):
     assert form.data['active'] is False
     assert form.roles.data == [user.roles[0]]
     assert form.groups.data == [user.roles[1]]
+
+# .tox/c1/bin/pytest --cov=invenio_accounts tests/test_admin.py::test_userview_edit_form -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/invenio-accounts/.tox/c1/tmp
+def test_userview_edit_form(app, users):
+    """Test edit_form for super role user."""
+    view = UserView(User, db.session)
+    form = view.edit_form()
+    assert form.data['active'] is False


### PR DESCRIPTION
ユーザー管理画面の作成編集タブで表示されるフォームを修正しました。

1. ユーザーのロールとグループの管理:
UserViewクラス内で、rolesおよびgroupsフィールドをQuerySelectMultipleFieldに変更し、
選択可能なロールとグループを動的にロードするようにしています。
これにより、"\_groups\_"を含むロールと含まないロールを別々に表示し、選択できるようになります。

2. テストの追加
  追加した以下のメソッドが正しく動作するかをテストしています。
    - on_form_prefill
    - edit_form