### PR TITLE
コミュニティ新規作成時のエラー修正 & 初期データ登録修正

### DIFF
--- a/modules/invenio-communities/invenio_communities/admin.py
+++ b/modules/invenio-communities/invenio_communities/admin.py
@@ -122,7 +122,6 @@ class CommunityModelView(ModelView):
                 model.id = form_data['id']
                 model.id_role = form_data['owner']
                 model.root_node_id = form_data['index']
-                model.group_id = form_data['group']
                 model.title = form_data['title']
                 model.description = form_data['description']
                 model.page = form_data['page']
@@ -134,6 +133,8 @@ class CommunityModelView(ModelView):
                     model.login_menu_enabled = True
                 else:
                     model.login_menu_enabled = False
+                if form_data.get('group') != "__None":
+                    model.group_id = form_data.get('group')
                 the_result = {
                     "FILE_PATTERN": "Thumbnail file only 'jpeg', 'jpg', 'png' format.",
                 }
@@ -295,7 +296,6 @@ class CommunityModelView(ModelView):
             try:
                 model.id_role = form_data['owner']
                 model.root_node_id = form_data['index']
-                model.group_id = form_data['group']
                 model.title = form_data['title']
                 model.description = form_data['description']
                 model.page = form_data['page']
@@ -307,6 +307,8 @@ class CommunityModelView(ModelView):
                     model.login_menu_enabled = True
                 else:
                     model.login_menu_enabled = False
+                if form_data.get('group') != "__None":
+                    model.group_id = form_data.get('group')
                 the_result = {
                     "FILE_PATTERN": "Thumbnail file only 'jpeg', 'jpg', 'png' format.",
                 }

--- a/modules/invenio-communities/tests/test_admin.py
+++ b/modules/invenio-communities/tests/test_admin.py
@@ -180,7 +180,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": object()
+                "thumbnail": object(),
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 400
@@ -199,7 +200,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": object()
+                "thumbnail": object(),
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 400
@@ -218,7 +220,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": object()
+                "thumbnail": object(),
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 400
@@ -240,7 +243,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file1
+                "thumbnail": file1,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 302
@@ -257,6 +261,7 @@ class TestCommunityModelView():
                 "id": "file2",
                 "owner": 1,
                 "index": 11,
+                "group": 1,
                 "title": "Test comm after",
                 "description": "this is description of community1.",
                 "page":"",
@@ -265,7 +270,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{}}",
-                "thumbnail": file2
+                "thumbnail": file2,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 302
@@ -278,6 +284,7 @@ class TestCommunityModelView():
                 "id": "file3",
                 "owner": 1,
                 "index": 11,
+                "group": 1,
                 "title": "Test comm after",
                 "description": "this is description of community1.",
                 "page":"",
@@ -286,7 +293,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{}}",
-                "thumbnail": file3
+                "thumbnail": file3,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 400
@@ -299,6 +307,7 @@ class TestCommunityModelView():
                 "id": "file4",
                 "owner": 1,
                 "index": 11,
+                "group": 1,
                 "title": "Test comm after",
                 "description": "this is description of community1.",
                 "page":"",
@@ -307,7 +316,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{}}",
-                "thumbnail": file4
+                "thumbnail": file4,
+                "content_policy":""
             }
             with patch("weko_gridlayout.services.WidgetDesignPageServices.add_or_update_page", return_value={'result': False, 'error': 'error'}):
                 res = client.post(url,data=data)
@@ -321,6 +331,7 @@ class TestCommunityModelView():
                 "id": "file5",
                 "owner": 1,
                 "index": 11,
+                "group": 1,
                 "title": "Test comm after",
                 "description": "this is description of community1.",
                 "page":"",
@@ -329,7 +340,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file5
+                "thumbnail": file5,
+                "content_policy":""
             }
             app.config['WEKO_HANDLE_ALLOW_REGISTER_CNRI'] = True
             with patch("weko_handle.api.Handle.register_handle", return_value='1234567890/1'):
@@ -346,6 +358,7 @@ class TestCommunityModelView():
                 "id": "file6",
                 "owner": 1,
                 "index": 11,
+                "group": 1,
                 "title": "Test comm after",
                 "description": "this is description of community1.",
                 "page":"",
@@ -354,7 +367,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file6
+                "thumbnail": file6,
+                "content_policy":""
             }
             app.config['WEKO_HANDLE_ALLOW_REGISTER_CNRI'] = True
             with patch("weko_handle.api.Handle.register_handle", return_value=None):
@@ -403,7 +417,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file1
+                "thumbnail": file1,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 302
@@ -428,7 +443,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file6
+                "thumbnail": file6,
+                "content_policy":""
             }
             with patch("invenio_communities.admin.os.remove", side_effect=Exception()):
                 res = client.post(url,data=data)
@@ -450,7 +466,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file7
+                "thumbnail": file7,
+                "content_policy":""
             }
             app.config['WEKO_HANDLE_ALLOW_REGISTER_CNRI'] = True
             with patch("weko_handle.api.Handle.register_handle", return_value=None):
@@ -475,7 +492,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file8
+                "thumbnail": file8,
+                "content_policy":""
             }
             app.config['WEKO_HANDLE_ALLOW_REGISTER_CNRI'] = True
             with patch("weko_handle.api.Handle.register_handle", return_value='1234567890/1'):
@@ -500,7 +518,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file9
+                "thumbnail": file9,
+                "content_policy":""
             }
             app.config['WEKO_HANDLE_ALLOW_REGISTER_CNRI'] = True
             with patch("weko_handle.api.Handle.register_handle", return_value='1234567890/2'):
@@ -526,7 +545,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file2
+                "thumbnail": file2,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 400
@@ -547,7 +567,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{}}",
-                "thumbnail": file3
+                "thumbnail": file3,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 302
@@ -568,7 +589,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{}}",
-                "thumbnail": file4
+                "thumbnail": file4,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 302
@@ -590,7 +612,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":False,
                 "catalog_data": "{\"metainfo\":{}}",
-                "thumbnail": file5
+                "thumbnail": file5,
+                "content_policy":""
             }
             res = client.post(url_none,data=data)
             assert res.status_code == 404
@@ -623,7 +646,8 @@ class TestCommunityModelView():
                 "fixed_points":0,
                 "login_menu_enabled":True,
                 "catalog_data": "{\"metainfo\":{\"parentkey\":[{\"catalog_contributors\":[{\"contributor_names\":[{\"contributor_name\":\"提供機関名\",\"contributor_name_language\":\"ja\"}],\"contributor_type\":\"HostingInstitution\"}],\"catalog_identifiers\":[{}],\"catalog_subjects\":[{}],\"catalog_licenses\":[{}],\"catalog_rights\":[{}],\"catalog_access_rights\":[{}]}]}}",
-                "thumbnail": file1
+                "thumbnail": file1,
+                "content_policy":""
             }
             res = client.post(url,data=data)
             assert res.status_code == 302

--- a/scripts/demo/defaultworkflow.sql
+++ b/scripts/demo/defaultworkflow.sql
@@ -21,7 +21,7 @@ SET row_security = off;
 -- Data for Name: workflow_flow_define; Type: TABLE DATA; Schema: public; Owner: invenio
 --
 
-INSERT INTO public.workflow_flow_define (status, created, updated, id, flow_id, flow_name, flow_user, flow_status, is_deleted) VALUES ('N', '2024-06-12 21:30:19.564693', '2024-06-12 21:31:01.443099', 1, '95b9a88f-3318-4da4-8949-7345b9396e87', 'Registration Flow', 1, 'A', false);
+INSERT INTO public.workflow_flow_define (status, created, updated, id, flow_id, flow_name, flow_user, flow_status, is_deleted, repository_id) VALUES ('N', '2024-06-12 21:30:19.564693', '2024-06-12 21:31:01.443099', 1, '95b9a88f-3318-4da4-8949-7345b9396e87', 'Registration Flow', 1, 'A', false, 'Root Index');
 
 
 --
@@ -40,8 +40,8 @@ INSERT INTO public.workflow_flow_action (status, created, updated, id, flow_id, 
 -- Data for Name: workflow_workflow; Type: TABLE DATA; Schema: public; Owner: invenio
 --
 
-INSERT INTO public.workflow_workflow (status, created, updated, id, flows_id, flows_name, itemtype_id, index_tree_id, flow_id, is_deleted, open_restricted, location_id, is_gakuninrdm) VALUES ('N', '2024-06-12 21:33:29.550958', '2024-06-12 21:33:29.550985', 1, '4bb9d036-fc1e-4eab-a7de-cffed26a2bb4', 'デフォルトアイテムタイプ（フル）', 30002, NULL, 1, false, false, NULL, false);
-INSERT INTO public.workflow_workflow (status, created, updated, id, flows_id, flows_name, itemtype_id, index_tree_id, flow_id, is_deleted, open_restricted, location_id, is_gakuninrdm) VALUES ('N', '2024-06-12 21:33:55.106678', '2024-06-12 21:33:55.106704', 2, 'bbbb1d7f-2e3a-4bb2-945c-d71b221cb068', 'デフォルトアイテムタイプ（シンプル）', 30001, NULL, 1, false, false, NULL, false);
+INSERT INTO public.workflow_workflow (status, created, updated, id, flows_id, flows_name, itemtype_id, index_tree_id, flow_id, is_deleted, open_restricted, location_id, is_gakuninrdm, repository_id) VALUES ('N', '2024-06-12 21:33:29.550958', '2024-06-12 21:33:29.550985', 1, '4bb9d036-fc1e-4eab-a7de-cffed26a2bb4', 'デフォルトアイテムタイプ（フル）', 30002, NULL, 1, false, false, NULL, false, 'Root Index');
+INSERT INTO public.workflow_workflow (status, created, updated, id, flows_id, flows_name, itemtype_id, index_tree_id, flow_id, is_deleted, open_restricted, location_id, is_gakuninrdm, repository_id) VALUES ('N', '2024-06-12 21:33:55.106678', '2024-06-12 21:33:55.106704', 2, 'bbbb1d7f-2e3a-4bb2-945c-d71b221cb068', 'デフォルトアイテムタイプ（シンプル）', 30001, NULL, 1, false, false, NULL, false, 'Root Index');
 
 
 --


### PR DESCRIPTION
## 概要
このPRでは、以下の2つの変更を含みます：

### 1.  コミュニティ新規作成時のエラーを修正

CommunityModelViewのcreate_viewのDB登録処理を修正しました。
また、修正箇所のテストコードを修正、実施しました。

### 2. ワークフローの初期データ登録でのエラーを修正

ワークフローにカラムを追加した影響で初期データが登録できなかったため、defaultworkflow.sqlを修正しました。

以上、よろしくお願いします。