### PR TITLE
export_allのindex_id_listの処理を修正

### DIFF
--- a/modules/weko-search-ui/weko_search_ui/utils.py
+++ b/modules/weko-search-ui/weko_search_ui/utils.py
@@ -3367,7 +3367,7 @@ def export_all(root_url, user_id, data, timezone):
         from weko_index_tree.api import Indexes
 
         if not user_id:
-            return None
+            return []
         user = User.query.get(user_id)
         if any(role.name in current_app.config['WEKO_PERMISSION_SUPER_ROLE_USER'] for role in user.roles):
             return None
@@ -3456,8 +3456,13 @@ def export_all(root_url, user_id, data, timezone):
                 if len(recids) == 0:
                     item_types.remove(it)
                     continue
-
-                record_ids = [(recid.pid_value, recid.object_uuid)
+                
+                if index_id_list is None:
+                    record_ids = [(recid.pid_value, recid.object_uuid)
+                    for recid in recids if 'publish_status' in recid.json
+                    and recid.json['publish_status'] in [PublishStatus.PUBLIC.value, PublishStatus.PRIVATE.value]]
+                else:
+                    record_ids = [(recid.pid_value, recid.object_uuid)
                     for recid in recids if 'publish_status' in recid.json
                     and recid.json['publish_status'] in [PublishStatus.PUBLIC.value, PublishStatus.PRIVATE.value]
                     and any(index in recid.json['path'] for index in  index_id_list)]


### PR DESCRIPTION
weko_search_uiのexport_all()を修正しました。

index_id_listがNoneの場合にシステム管理者としてすべてのアイテムを取得する処理になっていなかったので修正しました。