### PR TITLE
fix error

### DIFF
--- a/modules/invenio-accounts/invenio_accounts/admin.py
+++ b/modules/invenio-accounts/invenio_accounts/admin.py
@@ -202,7 +202,7 @@ class UserView(ModelView):
 
     _system_role = os.environ.get('INVENIO_ROLE_SYSTEM',
                                   'System Administrator')
-    _repo_role = os.environ.get('INVENIO_ROLE_REPOSITORY'
+    _repo_role = os.environ.get('INVENIO_ROLE_REPOSITORY',
                                 'Repository Administrator')
     _com_role = os.environ.get('INVENIO_ROLE_COMMUNITY',
                                'Community Administrator')

--- a/modules/weko-admin/weko_admin/views.py
+++ b/modules/weko-admin/weko_admin/views.py
@@ -578,7 +578,7 @@ def get_site_license_send_mail_settings():
         SiteLicenseInfo.organization_id).all()
     settings = AdminSettings.get('site_license_mail_settings', dict_to_object=False)
     if settings:    
-        setting = settings.get(repo_id)
+        setting = settings.get(repo_id, {'auto_send_flag': False})
     else:
         setting = {'auto_send_flag': False}
     


### PR DESCRIPTION
### 概要
結合テストで発生したエラーを修正しました。

### 修正内容
- リポジトリ管理者のユーザー管理画面の一覧タブで編集アイコンと削除アイコンが表示されない不具合の修正
os.environ.getのキーとデフォルト値の間のカンマが抜けていたのを修正しました。

- サイトライセンス画面でリポジトリ選択プルダウンから選択した際のエラーを修正
設定が作成されていないリポジトリの時に
`TypeError: 'NoneType' object is not subscriptable`
となっていたのを修正しました。