### PR TITLE
Fix/user provisioning test

### DIFF
--- a/modules/weko-accounts/tests/test_views.py
+++ b/modules/weko-accounts/tests/test_views.py
@@ -269,6 +269,19 @@ def test_confirm_user_without_page(client,redis_connect,mocker):
                 assert redis_connect.redis.exists("Shib-Session-1111") is False
                 
                 # exist ShibUser.shib_user
+                set_session(client,{"shib_session_id":"1111"})
+                redis_connect.put("Shib-Session-1111",bytes('{"shib_eppn":"test_eppn"}',"utf-8"))
+
+                shibuser = ShibUser({})
+                shibuser.shib_user = "test_user"
+                with patch("weko_accounts.views.ShibUser",return_value=shibuser):
+                    mock_redirect = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
+                    mock_flash = mocker.patch("weko_accounts.views.flash")
+                    client.get(url)
+                    mock_redirect.assert_called_with("/")
+                    assert redis_connect.redis.exists("Shib-Session-1111") is False
+                
+                # exist ShibUser.shib_user
                 set_session(client,{"shib_session_id":"1111","next":"/next_page"})
                 redis_connect.put("Shib-Session-1111",bytes('{"shib_eppn":"test_eppn"}',"utf-8"))
 

--- a/modules/weko-accounts/tests/test_views.py
+++ b/modules/weko-accounts/tests/test_views.py
@@ -251,9 +251,11 @@ def test_confirm_user_without_page(client,redis_connect,mocker):
             mock_flash = mocker.patch("weko_accounts.views.flash")
             client.get(url)
             mock_flash.assert_called_with("FAILED bind_relation_info!",category="error")
+            assert redis_connect.redis.exists("Shib-Session-1111") is False
         with patch("weko_accounts.views.ShibUser.bind_relation_info",return_value=True):
             # ShibUser.check_in is error
             with patch("weko_accounts.views.ShibUser.check_in",return_value="test_error"):
+                redis_connect.put("Shib-Session-1111",bytes('{"shib_eppn":"test_eppn"}',"utf-8"))
                 mock_flash = mocker.patch("weko_accounts.views.flash")
                 client.get(url)
                 mock_flash.assert_called_with("test_error",category="error")

--- a/modules/weko-accounts/weko_accounts/views.py
+++ b/modules/weko-accounts/weko_accounts/views.py
@@ -255,6 +255,7 @@ def confirm_user_without_page():
         # bind relation info
         if not shib_user.bind_relation_info(cache_val.get('shib_mail')):
             flash('FAILED bind_relation_info!', category='error')
+            datastore.delete(cache_key)
             return _redirect_method()
 
         # check in


### PR DESCRIPTION
#482　の追加対応
エラー後にRedis情報を削除する処理追加
それに合わせて該当箇所のテストコード修正