### PR TITLE
フィードバックメール送信の修正

### DIFF
--- a/modules/invenio-communities/invenio_communities/utils.py
+++ b/modules/invenio-communities/invenio_communities/utils.py
@@ -247,7 +247,7 @@ def get_repository_id_by_item_id(item_id):
     record = Record.get_record(item_id)
     index_id = record.get("path")
     index = Index.get_index_by_id(index_id[0])
-    repository_id = None
+    repository_id = "Root Index"
     while True:
         com = Community.query.filter_by(root_node_id=index.id).first()
         if com:

--- a/modules/weko-admin/weko_admin/models.py
+++ b/modules/weko-admin/weko_admin/models.py
@@ -1164,7 +1164,7 @@ class FeedbackMailSetting(db.Model, Timestamp):
         """
         try:
             with db.session.begin_nested():
-                settings = cls.query.all()[0]
+                settings = cls.query.filter_by(repository_id=repo_id).first()
                 settings.account_author = account_author
                 settings.manual_mail = manual_mail
                 settings.is_sending_feedback = is_sending_feedback

--- a/modules/weko-admin/weko_admin/tasks.py
+++ b/modules/weko-admin/weko_admin/tasks.py
@@ -36,7 +36,7 @@ from invenio_stats.utils import QueryCommonReportsHelper, \
 
 from weko_admin.api import TempDirInfo
 
-from .models import AdminSettings, StatisticsEmail
+from .models import AdminSettings, StatisticsEmail, FeedbackMailSetting
 from .utils import StatisticMail, get_user_report_data, package_reports ,elasticsearch_reindex
 from .views import manual_send_site_license_mail 
 from celery.task.control import inspect
@@ -185,7 +185,10 @@ def check_send_all_reports():
 def send_feedback_mail():
     """Check Redis periodically for when to run a task."""
     with current_app.app_context():
-        StatisticMail.send_mail_to_all()
+        setting = FeedbackMailSetting.get_feedback_email_setting_by_repo(repo_id='Root Index')
+        if setting:
+            if setting[0].is_sending_feedback:
+                StatisticMail.send_mail_to_all()
 
 
 def _due_to_run(schedule):

--- a/modules/weko-admin/weko_admin/utils.py
+++ b/modules/weko-admin/weko_admin/utils.py
@@ -596,6 +596,10 @@ class StatisticMail:
         if not setting.get('is_sending_feedback') and not stats_date:
             return
         banned_mail = cls.get_banned_mail(setting.get('data'))
+        if repo != "Root Index":
+            root_setting = FeedbackMail.get_feed_back_email_setting(repo_id='Root Index')
+            root_banned_mail= cls.get_banned_mail(root_setting.get('data'))
+            banned_mail = list(set(banned_mail + root_banned_mail))
 
         session = db.session
         id = FeedbackMailHistory.get_sequence(session)

--- a/modules/weko-records/weko_records/api.py
+++ b/modules/weko-records/weko_records/api.py
@@ -2391,7 +2391,7 @@ class FeedbackMailList(object):
         )
         
         if repo_id:
-            data.filter(_FeedbackMailList.repository_id == repo_id)
+            data = data.filter(_FeedbackMailList.repository_id == repo_id)
         data = data.all()
 
         # create return data


### PR DESCRIPTION
フィードバックメール送信処理を修正しました。

主な修正点
- フィードバックメールに記載するアイテムがサブリポジトリごとになっていなかった点を修正
フィードバックレポートを送信した際に、別のサブリポジトリのアイテムも含まれていた。
フィルタが有効に働いていなかった。

- Root Indexの設定がオフの時に送信しない処理になっていなかった点を修正
サブリポジトリの送信除外対象者にRoot Indexの送信除外対象者が含まれていなかった。