### PR TITLE
W-OA-IT-55,W-OA-IT-64

### DIFF
--- a/modules/weko-workflow/weko_workflow/api.py
+++ b/modules/weko-workflow/weko_workflow/api.py
@@ -3505,7 +3505,8 @@ class WorkActivityHistory(object):
         activity = WorkActivity()
         activity = activity.get_activity_detail(db_history.activity_id)
         if activity.action_id != db_history.action_id or \
-                activity.action_status != db_history.action_status:
+                activity.action_status != db_history.action_status or \
+                    activity.action_order != db_history.action_order:
             new_history = True
             activity.action_id = db_history.action_id
             activity.action_status = db_history.action_status
@@ -3532,7 +3533,7 @@ class WorkActivityHistory(object):
         """
         with db.session.no_autoflush:
             query = ActivityHistory.query.filter_by(
-                activity_id=activity_id).order_by(asc(ActivityHistory.id))
+                activity_id=activity_id).order_by(asc(ActivityHistory.action_order))
             histories = query.all()
             for history in histories:
                 history.ActionName = _Action.query.filter_by(

--- a/modules/weko-workflow/weko_workflow/utils.py
+++ b/modules/weko-workflow/weko_workflow/utils.py
@@ -1930,10 +1930,28 @@ def prepare_delete_workflow(post_activity, recid, deposit):
     rtn = activity.init_activity(
         post_activity, community, item_id
     )
+    activity_detail = activity.get_activity_detail(rtn.activity_id)
+    cur_action = activity_detail.action
     if rtn.action_id == 2:   # end_action
         from weko_records_ui.views import soft_delete
         soft_delete(recid.pid_value)
         activity.notify_about_activity(rtn.activity_id, "deleted")
+        activity.upt_activity_action_status(
+            activity_id=rtn.activity_id, 
+            action_id=rtn.action_id,
+            action_status=ActionStatusPolicy.ACTION_DONE,
+            action_order=rtn.action_order
+            )
+        act= dict(
+                activity_id=rtn.activity_id,
+                action_id=rtn.action_id,
+                action_version=cur_action.action_version,
+                action_status=ActionStatusPolicy.ACTION_DONE,
+                item_id=rtn.item_id,
+                action_order=rtn.action_order
+            )
+        
+        activity.end_activity(act)
 
     if rtn.action_id == 4:   # approval
         activity.notify_about_activity(rtn.activity_id, "deletion_request")


### PR DESCRIPTION
W-OA-IT-55
削除用ワークフローで「承認」のアクションがない場合、「END」アクションで「完了」ボタンを押さなければアクティビティが終了しない状態になってしまっているため、soft_delete時にアクティビティを終了させるよう修正。

W-OA-IT-64
削除用ワークフローで「承認」アクションがある時、削除ボタン押下後、「却下」をした場合に、前のアクションに戻って「作業中」で固定化されてしまう。前のアクションが「start」の場合に「作業中」になってしまうとアクティビティを終了することが出来ない状態になっている。
・「却下」された場合はprevious_actionメソッドに入る。ここで削除用の承認の「却下」だということを判断する。
・「却下」された場合は「END」を「作業済」にしてアクティビティを終了させる。
・「承認」が複数ある場合は、「却下」された「承認」以外を「スキップ」の状態にする。

modules/weko-workflow/weko_workflow/api.py
アクティビティのhistoryを取得する際に、action_order順に取得されるよう修正した。
workflow_action_historyに登録した順序で画面に表示されてしまっていたため。