### PR TITLE
Fix/w oa it 265 281

### DIFF
--- a/modules/weko-index-tree/tests/test_utils.py
+++ b/modules/weko-index-tree/tests/test_utils.py
@@ -110,7 +110,7 @@ def test_get_index_link_list(app, db, users):
     }]
     with patch("weko_index_tree.api.Indexes.get_browsing_tree_ignore_more", return_value=tree):
         assert get_index_link_list(10)==[(10, 'Index link 10'), (11, 'Index link 11')]
-        
+
 
 #+++ def is_index_tree_updated():
 def test_is_index_tree_updated(app):
@@ -162,11 +162,11 @@ def test_get_user_roles(i18n_app, client_rest, users):
         result = get_user_roles(is_super_role=True)
         assert result[0] == True
         assert result[1] == [1]
-        
+
         result = get_user_roles(is_super_role=False)
         assert result[0] == True
         assert result[1] == [1]
-        
+
     # comadmin
     with patch("flask_login.utils._get_user", return_value=users[4]['obj']):
         result = get_user_roles(is_super_role=True)
@@ -216,7 +216,7 @@ def test_check_roles(users):
     user_role = (True, [])
     roles = ["1","2"]
     check_roles(user_role, roles)
-    
+
     # not admin user
     ## not login
     ### not allow -99
@@ -248,7 +248,7 @@ def test_check_groups(i18n_app, users, db):
 
     user_group = ["group_test1", "group_test2"]
     groups = [v for k,v in Group.get_group_list().items()]
-    
+
     with patch("flask_login.utils._get_user", return_value=users[-1]['obj']):
         assert check_groups(user_group, groups)
 
@@ -371,7 +371,7 @@ def test_get_index_id_list(indices, db):
     index_list[0]['parent'] = str(index_list[0]['parent'])
 
     assert get_index_id_list(index_list)
-    
+
     index_list[0]['id'] = 'more'
 
     assert not get_index_id_list(index_list)
@@ -385,7 +385,7 @@ def test_get_publish_index_id_list(indices, db):
     index_list[0]['parent'] = str(index_list[0]['parent'])
 
     assert get_publish_index_id_list(index_list)
-    
+
     index_list[0]['id'] = 'more'
 
     assert not get_publish_index_id_list(index_list)
@@ -440,7 +440,7 @@ def test_get_elasticsearch_records_data_by_indexes(i18n_app, db_records, indices
     end_date = current_date.strftime("%Y-%m-%d")
 
     assert get_elasticsearch_records_data_by_indexes(idx_tree_ids, start_date, end_date)
-    
+
 
 #+++ def generate_path(index_ids):
 def test_generate_path(i18n_app, indices, esindex):
@@ -516,6 +516,8 @@ def test_check_doi_in_list_record_es(app, db, users):
 # .tox/c1/bin/pytest --cov=weko_index_tree tests/test_utils.py::test_check_restrict_doi_with_indexes -v -s -vv --cov-branch --cov-report=term --cov-config=tox.ini --basetemp=/code/modules/weko-index-tree/.tox/c1/tmp
 def test_check_restrict_doi_with_indexes(i18n_app, indices, db_records):
     assert not check_restrict_doi_with_indexes([33,44])
+    assert check_restrict_doi_with_indexes([1000])
+    assert not check_restrict_doi_with_indexes([33,1000])
 
 
 #*** def check_has_any_item_in_index_is_locked(index_id):
@@ -566,7 +568,7 @@ def test_lock_all_child_index(i18n_app, indices):
     value = indices['index_non_dict'].index_name
 
     assert lock_all_child_index(index_id, value)
-    
+
 
 #+++ def unlock_index(index_key):
 def test_unlock_index(i18n_app, indices):
@@ -575,7 +577,7 @@ def test_unlock_index(i18n_app, indices):
     locked_key_non_dict = f"lock_index_{indices['index_non_dict'].index_name}_non_dict"
     datastore.put(locked_key_dict, json.dumps({'1':'a'}).encode('utf-8'), ttl_secs=30)
     datastore.put(locked_key_non_dict, json.dumps({'1':'a'}).encode('utf-8'), ttl_secs=30)
-    
+
     unlock_index(locked_key_dict)
     unlock_index([locked_key_non_dict])
 
@@ -593,7 +595,7 @@ def test_validate_before_delete_index(i18n_app, indices):
 #+++ def is_index_locked(index_id):
 def test_is_index_locked(i18n_app, indices, redis_connect):
     datastore = redis_connect
-    
+
     locked_key_dict = f"lock_index_{indices['index_dict']['index_name']}_dict"
     key = f"{indices['index_dict']['index_name']}_dict"
     datastore.put(locked_key_dict, json.dumps({'1':'a'}).encode('utf-8'), ttl_secs=30)
@@ -662,7 +664,7 @@ def test_get_editing_items_in_index(app):
             with patch("invenio_pidstore.models.PersistentIdentifier.get", return_value=True):
                 res = get_editing_items_in_index(0)
                 assert res == ["1", "2"]
-        
+
         with patch("weko_items_ui.utils.check_item_is_being_edit", return_value=False):
             with patch("invenio_pidstore.models.PersistentIdentifier.get", return_value=True):
                 with patch("weko_workflow.utils.check_an_item_is_locked", return_value=False):
@@ -680,11 +682,11 @@ def test_save_index_trees_to_redis(app, redis_connect,caplog):
         # lang is None
         save_index_trees_to_redis(tree)
         assert json.loads(redis_connect.get("index_tree_view_test_en")) == [{"id":"1"}]
-        
+
         # lang is not None
         save_index_trees_to_redis(tree, lang="ja")
         assert json.loads(redis_connect.get("index_tree_view_test_ja")) == [{"id":"1"}]
-        
+
         # except ConnectionError
         with patch("simplekv.memory.redisstore.RedisStore.put",side_effect=ConnectionError("test_error")):
             save_index_trees_to_redis(tree, lang="ja")
@@ -716,10 +718,10 @@ def test_get_descendant_index_names(app, db, test_indices):
     result = get_descendant_index_names(1)
     assert result[0] == "テストインデックス 1"
     assert result[1] == "テストインデックス 1-/-テストインデックス 11"
-    
+
     result = get_descendant_index_names(11)
     assert result[0] == "テストインデックス 1-/-テストインデックス 11"
-    
+
     result = get_descendant_index_names(999)
     assert result == []
 
@@ -729,15 +731,15 @@ def test_get_item_ids_in_index():
     return_value = [{'_source': {'control_number': 123}}, {'_source': {'control_number': 456}}]
     with patch("weko_index_tree.utils.get_all_records_in_index", return_value=return_value):
         assert get_item_ids_in_index(1)==[123, 456]
-    
+
     return_value = []
     with patch("weko_index_tree.utils.get_all_records_in_index", return_value=return_value):
         assert get_item_ids_in_index(1)==[]
-    
+
     return_value = [{'key': 'value'}]
     with patch("weko_index_tree.utils.get_all_records_in_index", return_value=return_value):
-        assert get_item_ids_in_index(1)==[]     
-    
+        assert get_item_ids_in_index(1)==[]
+
 # def get_all_records_in_index(index_id):
 # .tox/c1/bin/pytest --cov=weko_index_tree tests/test_utils.py::test_get_all_records_in_index -v -s -vv --cov-branch --cov-report=term --cov-config=tox.ini --basetemp=/code/modules/weko-index-tree/.tox/c1/tmp
 def test_get_all_records_in_index(app, db, test_indices, mocker):
@@ -752,14 +754,14 @@ def test_get_all_records_in_index(app, db, test_indices, mocker):
     mock_search_instance = MagicMock()
     mock_search_instance.query.return_value.sort.return_value.params.return_value.execute.return_value.to_dict.return_value = first_page
     mocker.patch("weko_index_tree.utils.RecordsSearch", return_value=mock_search_instance)
-    
+
     index_id = 1
     result = get_all_records_in_index(index_id)
     assert result == [
         {'_source': {'control_number': 123}, 'sort': [1]},
         {'_source': {'control_number': 456}, 'sort': [2]}
     ]
-    
+
     first_page = {
         "hits": {
             "hits": [

--- a/modules/weko-index-tree/weko_index_tree/utils.py
+++ b/modules/weko-index-tree/weko_index_tree/utils.py
@@ -731,6 +731,7 @@ def check_restrict_doi_with_indexes(index_ids):
     """
     from .api import Indexes
     full_path_index_ids = [Indexes.get_full_path(_id) for _id in index_ids]
+    full_path_index_ids = [idx for idx in full_path_index_ids if idx != '']
     is_public = Indexes.is_public_state(full_path_index_ids)
     is_harvest_public = Indexes.get_harvest_public_state(full_path_index_ids)
     return not (is_public and is_harvest_public)

--- a/modules/weko-search-ui/tests/test_admin.py
+++ b/modules/weko-search-ui/tests/test_admin.py
@@ -14,6 +14,7 @@ from invenio_accounts.testutils import login_user_via_session
 
 from werkzeug.datastructures import FileStorage
 from weko_index_tree.models import Index
+from weko_records.models import ItemTypeJsonldMapping
 from weko_search_ui.admin import (
     ItemManagementBulkDelete,
     ItemManagementCustomSort,
@@ -448,18 +449,32 @@ def test_ItemRocrateImportView_get_disclaimer_text(i18n_app, users, client_reque
         test = ItemRocrateImportView()
         assert test.get_disclaimer_text()
 
-#     def export_template(self):
-# .tox/c1/bin/pytest --cov=weko_search_ui tests/test_admin.py::test_ItemRocrateImportView_export_template -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-search-ui/.tox/c1/tmp
-def test_ItemRocrateImportView_export_template(i18n_app, users, item_type):
-    _data = {
-        'item_type_id': 1
-    }
+#     def all_mappings(self):
+# .tox/c1/bin/pytest --cov=weko_search_ui tests/test_admin.py::test_ItemRocrateImportView_all_mappings -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-search-ui/.tox/c1/tmp
+def test_ItemRocrateImportView_all_mappings(i18n_app, users):
+    map1 = ItemTypeJsonldMapping(
+        id=1,
+        name="sample1",
+        mapping="{data:{}}",
+        item_type_id=30001,
+        version_id=6,
+        is_deleted=False
+    )
+    expect = [{
+                "id": 1,
+                "name": "sample1",
+                "item_type_id": 30001
+            }]
+
     with i18n_app.test_client() as client:
-        with patch("flask_login.utils._get_user", return_value=users[3]['obj']):
-            res = client.post("/admin/items/rocrate_import/export_template",
-                            data=json.dumps(_data),
-                            content_type="application/json")
-            assert res.status_code==200
+        with patch("flask_login.utils._get_user",
+                   return_value=users[3]['obj']):
+            with patch("weko_search_ui.admin.JsonldMapping.get_all",
+                       return_value=[map1]):
+                res = client.get("/admin/items/rocrate_import/all_mappings",
+                                 content_type="application/json")
+                assert res.status_code==200
+                assert res.json == expect
 
 
 # class ItemBulkExport(BaseView):

--- a/modules/weko-search-ui/weko_search_ui/admin.py
+++ b/modules/weko-search-ui/weko_search_ui/admin.py
@@ -52,7 +52,7 @@ from weko_index_tree.utils import (
 )
 from weko_logging.activity_logger import UserActivityLogger
 from weko_logging.models import UserActivityLog
-from weko_records.api import ItemTypes
+from weko_records.api import ItemTypes, JsonldMapping
 from weko_workflow.api import WorkFlow
 from weko_records_ui.external import call_external_system
 from weko_deposit.api import WekoRecord
@@ -1049,162 +1049,6 @@ class ItemRocrateImportView(BaseView):
         data = get_change_identifier_mode_content()
         return jsonify(code=1, data=data)
 
-    @expose("/export_template", methods=["POST"])
-    def export_template(self):
-        """Download item type template.
-
-        :return: The response of the download.
-        """
-        file_format = current_app.config.get('WEKO_ADMIN_OUTPUT_FORMAT', 'tsv').lower()
-        file_name = None
-        output_file = None
-        data = request.get_json()
-        if data:
-            item_type_id = int(data.get("item_type_id", 0))
-            if item_type_id > 0:
-                item_type = ItemTypes.get_by_id(id_=item_type_id, with_deleted=True)
-                if item_type:
-                    file_name = "{}({}).{}".format(
-                        item_type.item_type_name.name, item_type.id, file_format
-                    )
-                    item_type_line = [
-                        "#ItemType",
-                        "{}({})".format(item_type.item_type_name.name, item_type.id),
-                        "{}items/jsonschema/{}".format(request.url_root, item_type.id),
-                    ]
-                    ids_line = pickle.loads(pickle.dumps(WEKO_EXPORT_TEMPLATE_BASIC_ID, -1))
-                    names_line = pickle.loads(pickle.dumps(WEKO_EXPORT_TEMPLATE_BASIC_NAME, -1))
-                    systems_line = ["#"] + ["" for _ in range(len(ids_line) - 1)]
-                    options_line = pickle.loads(pickle.dumps(WEKO_EXPORT_TEMPLATE_BASIC_OPTION, -1))
-
-                    item_type = item_type.render
-                    meta_list = {
-                        **item_type.get("meta_fix", {}),
-                        **item_type.get("meta_list", {}),
-                    }
-                    meta_system = [key for key in item_type.get("meta_system", {})]
-                    schema = (
-                        item_type.get("table_row_map", {})
-                        .get("schema", {})
-                        .get("properties", {})
-                    )
-                    form = item_type.get("table_row_map", {}).get("form", [])
-
-                    count_file = 0
-                    count_thumbnail = 0
-                    for key in ["pubdate", *item_type.get("table_row", [])]:
-                        if key in meta_system:
-                            continue
-
-                        item = schema.get(key)
-                        item_option = meta_list.get(key) if meta_list.get(key) else item
-                        sub_form = next(
-                            (x for x in form if key == x.get("key")), {"title_i18n": {}}
-                        )
-                        root_id, root_name, root_option = get_root_item_option(
-                            key, item_option, sub_form
-                        )
-                        # have not sub item
-                        if not (item.get("properties") or item.get("items")):
-                            ids_line.append(root_id)
-                            names_line.append(root_name)
-                            systems_line.append("")
-                            options_line.append(", ".join(root_option))
-                        else:
-                            # have sub item
-                            sub_items = (
-                                item.get("properties")
-                                if item.get("properties")
-                                else item.get("items").get("properties")
-                            )
-                            _ids, _names = handle_get_all_sub_id_and_name(
-                                sub_items, root_id, root_name, sub_form.get("items", [])
-                            )
-                            _options = []
-                            for _id in _ids:
-                                if "filename" in _id:
-                                    ids_line.append(".file_path[{}]".format(count_file))
-                                    file_path_name = (
-                                        "File Path"
-                                        if current_i18n.language == "en"
-                                        else "ファイルパス"
-                                    )
-                                    names_line.append(
-                                        ".{}[{}]".format(file_path_name, count_file)
-                                    )
-                                    systems_line.append("")
-                                    options_line.append("Allow Multiple")
-                                    count_file += 1
-                                if "thumbnail_label" in _id:
-                                    thumbnail_path_name = (
-                                        "Thumbnail Path"
-                                        if current_i18n.language == "en"
-                                        else "サムネイルパス"
-                                    )
-                                    if item.get("items"):
-                                        ids_line.append(
-                                            ".thumbnail_path[{}]".format(
-                                                count_thumbnail
-                                            )
-                                        )
-                                        names_line.append(
-                                            ".{}[{}]".format(
-                                                thumbnail_path_name, count_thumbnail
-                                            )
-                                        )
-                                        options_line.append("Allow Multiple")
-                                        count_thumbnail += 1
-                                    else:
-                                        ids_line.append(".thumbnail_path")
-                                        names_line.append(
-                                            ".{}".format(thumbnail_path_name)
-                                        )
-                                        options_line.append("")
-                                    systems_line.append("")
-
-                                clean_key = _id.replace(".metadata.", "").replace(
-                                    "[0]", "[]"
-                                )
-                                _options.append(
-                                    get_sub_item_option(clean_key, form) or []
-                                )
-                                systems_line.append(
-                                    "System"
-                                    if check_sub_item_is_system(clean_key, form)
-                                    else ""
-                                )
-
-                            ids_line += _ids
-                            names_line += _names
-                            for _option in _options:
-                                options_line.append(
-                                    ", ".join(list(set(root_option + _option)))
-                                )
-                    output_file = make_file_by_line(
-                        [
-                            item_type_line,
-                            ids_line,
-                            names_line,
-                            systems_line,
-                            options_line,
-                        ]
-                    )
-        return Response(
-            []
-            if not output_file
-            else codecs.BOM_UTF8.decode("utf8")
-            + codecs.BOM_UTF8.decode()
-            + output_file.getvalue(),
-            mimetype="text/{}".format(file_format),
-            headers={
-                "Content-type": "text/{}; charset=utf-8".format(file_format),
-                "Content-disposition": "attachment; "
-                + (
-                    "filename=" if not file_name else urlencode({"filename": file_name})
-                ),
-            },
-        )
-
     @expose("/check_import_is_available", methods=["GET"])
     def check_import_available(self):
         """Check import is available.
@@ -1221,6 +1065,24 @@ class ItemRocrateImportView(BaseView):
             )
         else:
             return jsonify({"is_available": True})
+
+    @expose("/all_mappings", methods=["GET"])
+    def all_mappings(self):
+        """Get all ItemTypeJsonldMapping as JSON.
+
+        Returns:
+            flask.Response: JSON list of dicts with id, name, item_type_id,
+            retrieved from ItemTypeJsonldMapping records that are not deleted.
+        """
+        mappings = [
+            {
+                "id": item.id,
+                "name": item.name,
+                "item_type_id": item.item_type_id
+            }
+            for item in JsonldMapping.get_all()
+        ]
+        return jsonify(mappings)
 
 
 class ItemBulkExport(BaseView):

--- a/modules/weko-search-ui/weko_search_ui/static/js/weko_search_ui/rocrate_import.js
+++ b/modules/weko-search-ui/weko_search_ui/static/js/weko_search_ui/rocrate_import.js
@@ -64,6 +64,7 @@ const urlDownloadCheck = window.location.origin + '/admin/items/rocrate_import/d
 const urlDownloadImport = window.location.origin + '/admin/items/rocrate_import/export_import'
 const urlImport = window.location.origin + '/admin/items/rocrate_import/import'
 const urlCheckImportAvailable = window.location.origin + '/admin/items/rocrate_import/check_import_is_available'
+const urlAllMappings = window.location.origin + '/admin/items/rocrate_import/all_mappings'
 const step = {
   "SELECT_STEP": 0,
   "IMPORT_STEP": 1,
@@ -1169,7 +1170,7 @@ class MappingComponent extends React.Component {
   getListMapping() {
     const that = this;
     $.ajax({
-      url: "/sword/all_mappings",
+      url: urlAllMappings,
       type: 'GET',
       dataType: "json",
       success: function (data) {

--- a/modules/weko-swordserver/weko_swordserver/views.py
+++ b/modules/weko-swordserver/weko_swordserver/views.py
@@ -37,7 +37,6 @@ from weko_deposit.api import WekoRecord
 from weko_items_ui.scopes import item_create_scope, item_update_scope, item_delete_scope
 from weko_items_ui.utils import send_mail_direct_registered, send_mail_item_deleted
 from weko_notifications.utils import notify_item_imported, notify_item_deleted
-from weko_records.api import JsonldMapping
 from weko_records_ui.utils import get_record_permalink, soft_delete
 from weko_search_ui.utils import (
     import_items_to_system, import_items_to_activity,
@@ -992,23 +991,6 @@ def delete_object(recid):
         response = Response(status=204)
 
     return response
-
-
-@blueprint.route("/all_mappings", methods=["GET"])
-def all_mappings():
-    """Get all SwordItemTypeMapping list.
-
-    Returns:
-        SwordItemTypeMappingModel: All SwordItemTypeMapping list.
-    """
-    def convert(item):
-        return {
-            "id": item.id,
-            "name": item.name,
-            "item_type_id": item.item_type_id,
-        }
-    mappings = list(map(convert, JsonldMapping.get_all()))
-    return jsonify(mappings)
 
 
 def _create_error_document(type, error):


### PR DESCRIPTION
W-OA-IT-281

- RO-Crateインポートに使用するjsonldマッピング一覧取得のURLを、`/sword/all_mappings`から`/admin/items/rocrate_import/all_mappings`に変更
- `ItemRocrateImportView`の`export_template`は使用されないため削除
- 単体テスト、jsを合わせて修正

W-OA-IT-265
- 直接登録でDOI指定時、存在しないインデックスを指定すると`Indexes.get_full_path()`から空文字列が返却され後続でエラーになるため、空文字列を取り除くように修正