### PR TITLE
switch content policy input to WYSIWYG editor (Trumbowyg)

### DIFF
--- a/modules/invenio-communities/invenio_communities/bundles.py
+++ b/modules/invenio-communities/invenio_communities/bundles.py
@@ -54,6 +54,27 @@ ckeditor = Bundle(
     output='gen/communities_editor.%(version)s.js'
 )
 
+js_trumbowyg = NpmBundle(
+    "node_modules/trumbowyg/dist/trumbowyg.min.js",
+    "node_modules/trumbowyg/dist/plugins/colors/trumbowyg.colors.min.js",
+    "node_modules/trumbowyg/dist/plugins/fontfamily/trumbowyg.fontfamily.min.js",
+    "node_modules/trumbowyg/dist/plugins/fontsize/trumbowyg.fontsize.min.js",
+    "node_modules/trumbowyg/dist/plugins/table/trumbowyg.table.min.js",
+
+    npm={
+        'trumbowyg': '~2.25.1'
+    },
+    output='gen/communities_trumbowyg.%(version)s.js'
+)
+
+css_trumbowyg = Bundle(
+    "node_modules/trumbowyg/dist/ui/trumbowyg.min.css",
+    "node_modules/trumbowyg/dist/plugins/colors/ui/trumbowyg.colors.min.css",
+    "node_modules/trumbowyg/dist/plugins/table/ui/trumbowyg.table.min.css",
+    filters='cleancss',
+    output='gen/communities_trumbowyg.%(version)s.css'
+)
+
 css = NpmBundle(
     'scss/invenio_communities/communities.scss',
     filters='scss, cleancss',

--- a/modules/invenio-communities/invenio_communities/config.py
+++ b/modules/invenio-communities/invenio_communities/config.py
@@ -151,16 +151,30 @@ COMMUNITIES_ALLOWED_TAGS = [
     'sup',
     'u',
     'ul',
+    'hr',
+    'table',
+    'thead',
+    'tbody',
+    'tfoot',
+    'tr',
+    'th',
+    'td',
 ]
 """List of allowed tags used to sanitize HTML output for communities."""
 
 COMMUNITIES_ALLOWED_ATTRS = {
-    '*': ['class'],
+    '*': ['class', 'style'],
     'a': ['href', 'title', 'name', 'class', 'rel'],
     'abbr': ['title'],
     'acronym': ['title'],
 }
 """List of allowed attributes used to sanitize HTML output for communities."""
+
+COMMUNITIES_ALLOWED_STYLES = [
+    'font-family', 'font-size', 'color', 'background-color',
+    'text-align', 'font-weight', 'font-style', 'text-decoration',
+]
+"""List of allowed styles used to sanitize HTML output for communities."""
 
 COMMUNITIES_LIMITED_ROLE_ACCESS_PERMIT = 2
 """Allowed Role's id higher than this number full access to list Indexes."""

--- a/modules/invenio-communities/invenio_communities/static/js/invenio_communities/app.js
+++ b/modules/invenio-communities/invenio_communities/static/js/invenio_communities/app.js
@@ -321,3 +321,26 @@ var CustomBSDatePicker = {
     });
   }
 }
+
+$(document).ready(function () {
+  $('#content_policy').trumbowyg({
+    autogrow: true,
+    tagsToRemove: ['script', 'link'],
+    svgPath: '/static/node_modules/trumbowyg/dist/ui/icons.svg',
+    btns: [
+      ["viewHTML"],
+      ["undo", "redo"],
+      ["formatting"],
+      ['fontfamily', 'fontsize'],
+      ["strong", "em", "del", 'underline', "superscript", "subscript"],
+      ['foreColor', 'backColor'],
+      ["link"],
+      ['table'],
+      ["justifyLeft", "justifyCenter", "justifyRight", "justifyFull"],
+      ["unorderedList", "orderedList"],
+      ["horizontalRule"],
+      ["removeformat"],
+      ["fullscreen"]
+    ],
+  });
+});

--- a/modules/invenio-communities/invenio_communities/templates/invenio_communities/admin/edit.html
+++ b/modules/invenio-communities/invenio_communities/templates/invenio_communities/admin/edit.html
@@ -6,12 +6,14 @@
   {% assets "invenio_deposit_css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
   {{ super() }}
   <link href="{{ url_for('static', filename='scss/invenio_communities/extra_fields.css') }}" rel="stylesheet">
+  {% assets "invenio_communities_trumbowyg_css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {%- endblock css %}
 
 {%- block javascript %}
   {% assets "invenio_deposit_dependencies_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {{ super() }}
   {% assets "invenio_deposit_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "invenio_communities_trumbowyg_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   <script src="{{ url_for('static', filename='js/invenio_communities/app.js') }}"></script>
 {%- endblock javascript %}
 

--- a/modules/invenio-communities/invenio_communities/templates/invenio_communities/content_policy.html
+++ b/modules/invenio-communities/invenio_communities/templates/invenio_communities/content_policy.html
@@ -61,15 +61,9 @@
 
     {%- block page_body_main %}
     <div class="content-policy container py-5">
-      <div class="text-left mb-4">
-        <h1 class="display-4">コンテンツポリシー</h1>
-        <hr class="w-50 mx-auto">
-      </div>
       <div class="policy-content">
         {% if community.content_policy %}
-          {% for line in community.content_policy.split('\n') %}
-            <p class="mb-3">{{ line|e }}</p>
-          {% endfor %}
+          {{ community.content_policy | sanitize_html | safe }}
         {% endif %}
       </div>
     </div>

--- a/modules/invenio-communities/invenio_communities/views/ui.py
+++ b/modules/invenio-communities/invenio_communities/views/ui.py
@@ -66,6 +66,7 @@ def sanitize_html(value):
         value,
         tags=current_app.config['COMMUNITIES_ALLOWED_TAGS'],
         attributes=current_app.config['COMMUNITIES_ALLOWED_ATTRS'],
+        styles=current_app.config['COMMUNITIES_ALLOWED_STYLES'],
         strip=True,
     ).strip()
 

--- a/modules/invenio-communities/setup.py
+++ b/modules/invenio-communities/setup.py
@@ -165,6 +165,8 @@ setup(
             'invenio_communities_css = invenio_communities.bundles:css',
             'invenio_communities_css_tree = invenio_communities.bundles:css_tree',
             'invenio_communities_css_tree_display = invenio_communities.bundles:css_tree_display',
+            'invenio_communities_trumbowyg_js = invenio_communities.bundles:js_trumbowyg',
+            'invenio_communities_trumbowyg_css = invenio_communities.bundles:css_trumbowyg',
         ]
     },
     extras_require=extras_require,


### PR DESCRIPTION
コンテンツポリシー画面のhtmlタグを有効化。
サニタイズを修正。
コミュニティ管理画面のコンテンツポリシー入力欄をWYSIWYGエディターに変更 (Trumbowyg)
