### PR TITLE
add audit logs for sword api and update parent id calc process

### DIFF
--- a/modules/weko-logging/weko_logging/activity_logger.py
+++ b/modules/weko-logging/weko_logging/activity_logger.py
@@ -49,12 +49,14 @@ class UserActivityLogger:
             "target_key": target_key,
             "request_info": request_info,
             "community_id": community_id,
+            "required_commit": True,
             "remarks": remarks,
         })
 
     @classmethod
     def info(cls, operation=None, parent_id=None,
-             target_key=None, request_info=None, remarks=None):
+             target_key=None, request_info=None, 
+             required_commit=True, remarks=None):
         """Output as info log.
 
         Args:
@@ -62,6 +64,7 @@ class UserActivityLogger:
             parent_id (int): Parent log id.
             target_key (str): Operation target key (e.g. id).
             request_info (dict): Request information (Required if called by shared task).
+            required_commit (bool): Whether to commit the log.
             remarks (str): Remarks.
         """
         user_id = UserActivityLogHandler.get_user_id()
@@ -76,6 +79,7 @@ class UserActivityLogger:
             "target_key": target_key,
             "request_info": request_info,
             "community_id": community_id,
+            "required_commit": required_commit,
             "remarks": remarks,
         })
 

--- a/modules/weko-logging/weko_logging/handler.py
+++ b/modules/weko-logging/weko_logging/handler.py
@@ -109,6 +109,7 @@ class UserActivityLogHandler(logging.Handler):
         user_activity_log = UserActivityLog(
             user_id=user_id,
             log={},
+            parent_id=parent_id,
             community_id=community_id,
             remarks=remarks,
         )
@@ -135,7 +136,8 @@ class UserActivityLogHandler(logging.Handler):
                 db.session.flush()
                 log["id"] = user_activity_log.id
                 user_activity_log.log = log
-            db.session.commit()
+            if hasattr(record, "required_commit") and record.required_commit:
+                db.session.commit()
         except Exception as e:
             db.session.rollback()
             current_app.logger.error(f"Failed to create user activity log: {e}")

--- a/modules/weko-logging/weko_logging/models.py
+++ b/modules/weko-logging/weko_logging/models.py
@@ -9,7 +9,7 @@
 
 from datetime import datetime, timezone
 
-from sqlalchemy import Sequence
+from sqlalchemy import text
 from sqlalchemy.dialects import mysql, postgresql
 from sqlalchemy_utils.types import JSONType
 
@@ -118,6 +118,7 @@ class UserActivityLog(db.Model):
         """
         if not session:
             session = db.session
-        seq = Sequence('user_activity_logs_id_seq')
-        next_id = session.execute(seq)
-        return next_id
+        # Get the current value of the sequence
+        result = session.execute(text("SELECT last_value FROM pg_sequences WHERE schemaname = 'public' AND sequencename = 'user_activity_logs_id_seq'"))
+        current_id = result.scalar()
+        return current_id + 1

--- a/modules/weko-workflow/weko_workflow/headless/activity.py
+++ b/modules/weko-workflow/weko_workflow/headless/activity.py
@@ -31,6 +31,7 @@ from weko_items_ui.utils import (
 from weko_items_ui.views import (
     check_validation_error_msg, prepare_edit_item, prepare_delete_item
 )
+from weko_logging.activity_logger import UserActivityLogger
 from weko_records.api import ItemTypes
 from weko_records.serializers.utils import get_mapping
 
@@ -631,6 +632,12 @@ class HeadlessActivity(WorkActivity):
                 file_size = file.tell()
                 file.seek(0)
                 file_info = upload(file.filename, file.stream, file_size)
+
+            UserActivityLogger.info(
+                operation="FILE_CREATE",
+                target_key=file_info.get("filename"),
+                required_commit=False
+            )
             files_info.append(file_info)
 
         return files_info


### PR DESCRIPTION
SWORD APIのインポート処理でファイル追加のログを追加。
parent_idのロジックを一部変更。Jsonには登録できていたが、columnになかったので追加できるようにした