### PR TITLE
単体テスト修正（weko-accounts）

### DIFF
--- a/modules/weko-accounts/tests/conftest.py
+++ b/modules/weko-accounts/tests/conftest.py
@@ -69,10 +69,10 @@ def base_app(instance_path):
         SECRET_KEY='SECRET_KEY',
         TESTING=True,
         SERVER_NAME='TEST_SERVER.localdomain',
-        SQLALCHEMY_DATABASE_URI=os.environ.get(
-         'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'),
-        #SQLALCHEMY_DATABASE_URI=os.getenv('SQLALCHEMY_DATABASE_URI',
-        #                                   'postgresql+psycopg2://invenio:dbpass123@postgresql:5432/wekotest'),
+        # SQLALCHEMY_DATABASE_URI=os.environ.get(
+        #  'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'),
+        SQLALCHEMY_DATABASE_URI=os.getenv('SQLALCHEMY_DATABASE_URI',
+                                          'postgresql+psycopg2://invenio:dbpass123@postgresql:5432/wekotest'),
         THEME_SITEURL = 'https://localhost',
         CACHE_REDIS_URL=os.environ.get(
             "CACHE_REDIS_URL", "redis://redis:6379/0"

--- a/modules/weko-accounts/tests/test_admin.py
+++ b/modules/weko-accounts/tests/test_admin.py
@@ -46,10 +46,12 @@ class TestShibSettingView:
             role_list = current_app.config['WEKO_ACCOUNTS_ROLE_LIST']
             attr_list = current_app.config['WEKO_ACCOUNTS_ATTRIBUTE_LIST']
             block_user_list = admin_settings[0].settings['blocked_ePPNs']
-            roles = admin_settings[2].settings
+            role_order = ["gakunin_role", "orthros_outside_role", "extra_role"]
+            roles = {key: admin_settings[2].settings[key] for key in role_order}
             set_language = "en"
             shib_flg = "1"
-            attributes = admin_settings[3].settings
+            attr_order = ["shib_eppn", "shib_role_authority_name", "shib_mail", "shib_user_name"]
+            attributes = {key: admin_settings[3].settings[key] for key in attr_order}
 
             data = {
                 "submit": "shib_form",

--- a/modules/weko-accounts/tests/test_api.py
+++ b/modules/weko-accounts/tests/test_api.py
@@ -300,9 +300,9 @@ class TestShibUser:
         app.config['WEKO_ACCOUNTS_IDP_ENTITY_ID'] = 'test_entity_id'
         app.config['CACHE_REDIS_DB'] = 1
         InvenioAccounts(app)
-        db_.init_app(app)
-        with app.app_context():
-            db_.create_all()
+        # db_.init_app(app)
+        # with app.app_context():
+        #     db_.create_all()
         return app
 
     @pytest.fixture
@@ -646,19 +646,21 @@ class TestShibUser:
 
 #    @classmethod
 #    def shib_user_logout(cls):
-# .tox/c1/bin/pytest --cov=weko_accounts tests/test_api.py::TestShibUser::test_shib_user_logout -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_shib_user_logout(self,request_context,users,mocker):
-        user = users[0]["obj"]
-        login_user(user)
-        mock_send = mocker.patch("weko_accounts.api.user_logged_out.send")
-        shibuser = ShibUser({})
-        shibuser.shib_user_logout()
-        mock_send.assert_called_with(current_app._get_current_object(),user=user)
+# .tox/c1/bin/pytest --cov=weko_accounts tests/test_api.py::test_shib_user_logout -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
+def test_shib_user_logout(request_context,users,mocker):
+    user = users[0]["obj"]
+    login_user(user)
+    mock_send = mocker.patch("weko_accounts.api.user_logged_out.send")
+    shibuser = ShibUser({})
+    shibuser.shib_user_logout()
+    mock_send.assert_called_with(current_app._get_current_object(),user=user)
+
+
 #def get_user_info_by_role_name(role_name):
 # .tox/c1/bin/pytest --cov=weko_accounts tests/test_api.py::test_get_user_info_by_role_name -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_get_user_info_by_role_name(users):
     result = get_user_info_by_role_name('Repository Administrator')
-    assert result == [users[1]["obj"],users[6]["obj"]]
+    assert result == [users[1]["obj"]]
 
 # .tox/c1/bin/pytest --cov=weko_accounts tests/test_api.py::test_sync_shib_gakunin_map_groups_success -vv -s --cov-branch --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_sync_shib_gakunin_map_groups_success(app, client):
@@ -737,7 +739,7 @@ def test_update_roles_add_new_roles(app, db, mocker):
     with app.app_context():
         # テストデータの準備
         map_group_list = ['group1', 'group2', 'group3','']
-        existing_role_names = {'group1', 'group4'}
+        existing_role_names = {'group1', 'jc_group4'}
 
         # 既存のロールを追加
         existing_roles = []
@@ -756,7 +758,7 @@ def test_update_roles_add_new_roles(app, db, mocker):
         assert 'group1' in role_names
         assert 'group2' in role_names  # 新しいロールが追加されていることを確認
         assert 'group3' in role_names  # 新しいロールが追加されていることを確認
-        assert 'group4' not in role_names  # 既存のロールが削除されていることを確認
+        assert 'jc_group4' not in role_names  # 既存のロールが削除されていることを確認
         assert '' not in role_names  # 空のロールが追加されていないことを確認
 
 #.tox/c1/bin/pytest --cov=weko_accounts tests/test_api.py::test_update_roles_with_permissions -vv -s --cov-branch --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
@@ -764,7 +766,7 @@ def test_update_roles_with_permissions(app, db, mocker):
     with app.app_context():
         # テストデータの準備
         map_group_list = ['group1', 'group2', 'group3', '']
-        existing_role_names = {'group1', 'group4'}
+        existing_role_names = {'group1', 'jc_group4'}
 
         # 既存のロールを追加
         existing_roles = []
@@ -784,23 +786,14 @@ def test_update_roles_with_permissions(app, db, mocker):
         db.session.commit()
 
         # 設定をモック
-        app.config['WEKO_INNDEXTREE_GAKUNIN_GROUP_DEFAULT_BROWSING_PERMISSION'] = True
-        app.config['WEKO_INNDEXTREE_GAKUNIN_GROUP_DEFAULT_CONTRIBUTE_PERMISSION'] = True
-
-        # APIモジュールのメソッドをモック
-        mock_update_browsing_role = mocker.patch('weko_accounts.api.update_browsing_role')
-        mock_remove_browsing_role = mocker.patch('weko_accounts.api.remove_browsing_role')
-        mock_update_contribute_role = mocker.patch('weko_accounts.api.update_contribute_role')
-        mock_remove_contribute_role = mocker.patch('weko_accounts.api.remove_contribute_role')
+        app.config['WEKO_INDEXTREE_GAKUNIN_GROUP_DEFAULT_BROWSING_PERMISSION'] = True
+        app.config['WEKO_INDEXTREE_GAKUNIN_GROUP_DEFAULT_CONTRIBUTE_PERMISSION'] = True
 
         # update_rolesの呼び出し
-        update_roles(map_group_list, existing_roles)
+        update_roles(map_group_list, existing_roles,[index1])
 
-        # APIモジュールのメソッドが呼び出されたことを確認
-        assert mock_update_browsing_role.call_count == 1
-        assert mock_remove_browsing_role.call_count == 1
-        assert mock_update_contribute_role.call_count == 1
-        assert mock_remove_contribute_role.call_count == 1
+        assert index1.browsing_role is not None
+
 
 def test_update_roles_with_permissions_false(app, db, mocker):
     with app.app_context():

--- a/modules/weko-accounts/tests/test_views.py
+++ b/modules/weko-accounts/tests/test_views.py
@@ -1,4 +1,5 @@
 
+from unittest.mock import MagicMock
 import pytest
 import json
 import redis
@@ -6,6 +7,7 @@ from invenio_accounts.models import Role
 from flask import url_for,request,make_response,current_app,Flask
 from flask_login.utils import login_user,logout_user
 from flask_menu import current_menu
+from flask_security import url_for_security
 from mock import patch
 from invenio_accounts.models import User
 from weko_accounts.api import ShibUser
@@ -59,11 +61,11 @@ def test_redirect_method(app,mocker):
         )
         mock_render = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
         _redirect_method(False)
-        mock_render.assert_called_with("http://TEST_SERVER.localdomain/secure/login.php")
+        mock_render.assert_called_with("http://TEST_SERVER.localdomain/secure/login.py")
 
         mock_render = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
         _redirect_method(True)
-        mock_render.assert_called_with("http://TEST_SERVER.localdomain/secure/login.php?next="+url)
+        mock_render.assert_called_with("http://TEST_SERVER.localdomain/secure/login.py?next="+url)
 
 #def index():
 # .tox/c1/bin/pytest --cov=weko_accounts tests/test_views.py::test_index -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
@@ -116,12 +118,15 @@ def test_shib_auto_login(client,redis_connect,mocker):
     set_session(client,{"shib_session_id":"1111"})
     with patch("weko_accounts.views.ShibUser.check_in",return_value=None):
         # is_auto_bind is true,shib_user is None
-        mock_redirect = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
-        client.get(url)
-        mock_new_relation.assert_called_once()
-        mock_shib_login.assert_not_called()
-        mock_redirect.assert_called_with("/")
-        assert redis_connect.redis.exists("Shib-Session-1111") == False
+        shibuser = ShibUser({})
+        shibuser.user = User(id=1)
+        with patch("weko_accounts.views.ShibUser",return_value=shibuser):
+            mock_redirect = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
+            client.get(url)
+            mock_new_relation.assert_called_once()
+            mock_shib_login.assert_not_called()
+            mock_redirect.assert_called_with("/")
+            assert redis_connect.redis.exists("Shib-Session-1111") == False
 
         # is_auto_bind is true,shib_user exis
         redis_connect.put("Shib-Session-1111",bytes('{"shib_eppn":"test_eppn"}',"utf-8"))
@@ -129,6 +134,7 @@ def test_shib_auto_login(client,redis_connect,mocker):
 
         shibuser = ShibUser({})
         shibuser.shib_user = "test_user"
+        shibuser.user = User(id=1)
         with patch("weko_accounts.views.ShibUser",return_value=shibuser):
             mock_redirect = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
             client.get(url+'?next=/next_page')
@@ -199,17 +205,21 @@ def test_confirm_user(client,redis_connect,mocker):
             with patch("weko_accounts.views.ShibUser.check_in",return_value=None):
                 # ShibUser.shib_user is None,not exist next in session
                 redis_connect.put("Shib-Session-1111",bytes('{"shib_eppn":"test_eppn"}',"utf-8"))
-                mock_redirect = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
-                client.post(url,data=form)
-                mock_redirect.assert_called_with("/")
-                assert redis_connect.redis.exists("Shib-Session-1111") is False
+                shibuser = ShibUser({})
+                shibuser.user = User(id=1)
+                with patch("weko_accounts.views.ShibUser",return_value=shibuser):
+                    mock_redirect = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
+                    client.post(url,data=form)
+                    mock_redirect.assert_called_with("/")
+                    assert redis_connect.redis.exists("Shib-Session-1111") is False
 
-                # exist ShibUser.shib_user
-                set_session(client,{"csrf_random":"test_csrf","shib_session_id":"1111","next":"/next_page"})
-                redis_connect.put("Shib-Session-1111",bytes('{"shib_eppn":"test_eppn"}',"utf-8"))
+                    # exist ShibUser.shib_user
+                    set_session(client,{"csrf_random":"test_csrf","shib_session_id":"1111","next":"/next_page"})
+                    redis_connect.put("Shib-Session-1111",bytes('{"shib_eppn":"test_eppn"}',"utf-8"))
 
                 shibuser = ShibUser({})
                 shibuser.shib_user = "test_user"
+                shibuser.user = User(id=1)
                 with patch("weko_accounts.views.ShibUser",return_value=shibuser):
                     mock_redirect = mocker.patch("weko_accounts.views.redirect",return_value=make_response())
                     mock_flash = mocker.patch("weko_accounts.views.flash")
@@ -647,7 +657,7 @@ def test_shib_sp_login(client, redis_connect,mocker, db, users):
     )
     res = client.post(url, data=form, headers=headers)
     assert res.status_code == 302
-    assert res.headers['Location'] == 'http://{}/login/'.format(current_app.config["SERVER_NAME"])
+    assert res.headers['Location'] == url_for("security.login", _external=True)
 
 
 #def shib_stub_login():
@@ -677,10 +687,11 @@ def test_shib_stub_login(client,mocker):
 
 #def shib_logout():
 # .tox/c1/bin/pytest --cov=weko_accounts tests/test_views.py::test_shib_logout -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_shib_logout(client, mocker):
-    mocker.patch("weko_accounts.views.ShibUser.shib_user_logout")
-    res = client.get(url_for("weko_accounts.shib_logout"))
-    assert res.data == bytes("logout success","utf-8")
+def test_shib_logout(client, users, mocker):
+    with patch("flask_login.utils._get_user", return_value=users[0]['obj']):
+        mocker.patch("weko_accounts.views.ShibUser.shib_user_logout")
+        res = client.get(url_for("weko_accounts.shib_logout"))
+        assert res.data == bytes("logout success","utf-8")
 
 # def find_user_by_email(shib_attributes):
 # .tox/c1/bin/pytest --cov=weko_accounts tests/test_views.py::test_find_user_by_email -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp

--- a/modules/weko-accounts/weko_accounts/api.py
+++ b/modules/weko-accounts/weko_accounts/api.py
@@ -515,8 +515,8 @@ def update_roles(map_group_list, roles, indices=[]):
     """Update roles based on map group list."""
     role_names = set({role.name for role in roles})
 
-    new_role_names = [role_name for role_name in map_group_list if not role_name or role_name in role_names]
-    roles_to_remove = [role_name for role_name in role_names if role_name not in map_group_list and role_name.statswith('jc_')]
+    new_role_names = [role_name for role_name in map_group_list if role_name and role_name not in role_names]
+    roles_to_remove = [role_name for role_name in role_names if role_name not in map_group_list and role_name.startswith('jc_')]
 
     
     new_roles = []
@@ -534,7 +534,7 @@ def update_roles(map_group_list, roles, indices=[]):
                 role_to_remove = Role.query.filter_by(name=role_name).one()
                 remove_role_ids.append(role_to_remove.id)
                 db.session.delete(role_to_remove)
-            db.session.commit()
+        db.session.commit()
     except Exception as ex:
         current_app.logger.error(f"Error adding new roles: {ex}")
         db.session.rollback()

--- a/modules/weko-accounts/weko_accounts/rest.py
+++ b/modules/weko-accounts/weko_accounts/rest.py
@@ -176,12 +176,12 @@ class WekoLogout(ContentNegotiatedMethodView):
     def post_v1(self, **kwargs):
 
         # Logout
-        user_id = current_user.id
         if current_user.is_authenticated:
+            user_id = current_user.id
             logout_user()
 
-        UserActivityLogger.info(
-            operation="LOGOUT",
-            target_key=user_id
-        )
+            UserActivityLogger.info(
+                operation="LOGOUT",
+                target_key=user_id
+            )
         return make_response('', 200)


### PR DESCRIPTION
Coverage: 29% -> 83% (改修前: 92 %)
1 failed, 6 passed, 43 error -> 1 failed, 49 passed (改修前: 2 failed, 38 passed)