### PR TITLE
fix: :bug: fix generating index_url

### DIFF
--- a/modules/weko-handle/setup.py
+++ b/modules/weko-handle/setup.py
@@ -81,6 +81,9 @@ setup(
         'invenio_base.api_blueprints': [
             'weko_handle = weko_handle.views:blueprint_api',
         ],
+        'invenio_base.api_apps': [
+            'weko_handle = weko_handle:WekoHandle',
+        ],
         # TODO: Edit these entry points to fit your needs.
         # 'invenio_access.actions': [],
         # 'invenio_admin.actions': [],

--- a/modules/weko-handle/weko_handle/ext.py
+++ b/modules/weko-handle/weko_handle/ext.py
@@ -31,7 +31,7 @@ class WekoHandle(object):
         """Flask application initialization."""
         self.init_config(app)
 
-        app.register_blueprint(blueprint)
+        # app.register_blueprint(blueprint)
         app.extensions['weko-handle'] = self
 
     def init_config(self, app):

--- a/modules/weko-handle/weko_handle/views.py
+++ b/modules/weko-handle/weko_handle/views.py
@@ -27,7 +27,7 @@ blueprint = Blueprint(
 )
 
 blueprint_api = Blueprint(
-    'weko_handle',
+    'weko_handle_api',
     __name__,
     template_folder='templates',
     static_folder='static',

--- a/modules/weko-index-tree/tests/conftest.py
+++ b/modules/weko-index-tree/tests/conftest.py
@@ -71,6 +71,7 @@ from invenio_oauth2server.models import Client, Token
 from invenio_pidrelations import InvenioPIDRelations
 from invenio_records import InvenioRecords
 from invenio_search import InvenioSearch
+from invenio_search_ui import InvenioSearchUI
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 from simplekv.memory.redisstore import RedisStore
 from invenio_oaiharvester.models import HarvestSettings
@@ -457,6 +458,7 @@ def base_app(instance_path):
     InvenioCache(app_)
     InvenioJSONSchemas(app_)
     InvenioSearch(app_)
+    InvenioSearchUI(app_)
     InvenioRecords(app_)
     InvenioIndexer(app_)
     InvenioI18N(app_)

--- a/modules/weko-index-tree/tests/test_api.py
+++ b/modules/weko-index-tree/tests/test_api.py
@@ -1149,10 +1149,11 @@ def test_get_index_with_role_group(app, db, mocker):
 
 # .tox/c1/bin/pytest --cov=weko_index_tree tests/test_api.py::test_indexes_get_handle_index_url -v -s -vv --cov-branch --cov-report=html --cov-config=tox.ini --basetemp=/code/modules/weko-index-tree/.tox/c1/tmp
 def test_indexes_get_handle_index_url(app, db, users, test_indices, mocker):
-    mock_handle = mocker.MagicMock()
-    mock_handle.register_handle.return_value="https://test/handle/1"
-    mocker.patch("weko_index_tree.api.Handle", return_value=mock_handle)
-    app.config['WEKO_HANDLE_CREDS_JSON_PATH'] = '/code/modules/resources/handle_creds.json'
-    handle, index_url = Indexes.get_handle_index_url(1)
-    assert index_url == "http://test_server/search?search_type=2&q=1"
-    assert handle == "https://test/handle/1"
+    with app.test_request_context():
+        mock_handle = mocker.MagicMock()
+        mock_handle.register_handle.return_value="https://test/handle/1"
+        mocker.patch("weko_index_tree.api.Handle", return_value=mock_handle)
+        app.config['WEKO_HANDLE_CREDS_JSON_PATH'] = '/code/modules/resources/handle_creds.json'
+        handle, index_url = Indexes.get_handle_index_url(1)
+        assert index_url == "http://TEST_SERVER/search?search_type=2&q=1"
+        assert handle == "https://test/handle/1"

--- a/modules/weko-index-tree/tests/test_api.py
+++ b/modules/weko-index-tree/tests/test_api.py
@@ -1145,3 +1145,14 @@ def test_get_index_with_role_group(app, db, mocker):
         assert result['browsing_group']['deny'] == []
         assert result['contribute_group']['allow'] == []
         assert result['contribute_group']['deny'] == []
+
+
+# .tox/c1/bin/pytest --cov=weko_index_tree tests/test_api.py::test_indexes_get_handle_index_url -v -s -vv --cov-branch --cov-report=html --cov-config=tox.ini --basetemp=/code/modules/weko-index-tree/.tox/c1/tmp
+def test_indexes_get_handle_index_url(app, db, users, test_indices, mocker):
+    mock_handle = mocker.MagicMock()
+    mock_handle.register_handle.return_value="https://test/handle/1"
+    mocker.patch("weko_index_tree.api.Handle", return_value=mock_handle)
+    app.config['WEKO_HANDLE_CREDS_JSON_PATH'] = '/code/modules/resources/handle_creds.json'
+    handle, index_url = Indexes.get_handle_index_url(1)
+    assert index_url == "http://test_server/search?search_type=2&q=1"
+    assert handle == "https://test/handle/1"

--- a/modules/weko-index-tree/weko_index_tree/api.py
+++ b/modules/weko-index-tree/weko_index_tree/api.py
@@ -29,7 +29,7 @@ import traceback
 
 from b2handle.clientcredentials import PIDClientCredentials
 from redis.exceptions import RedisError
-from flask import current_app, json, request, url_for
+from flask import current_app, json, request
 from flask_babelex import gettext as _
 from flask_login import current_user
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -2086,8 +2086,7 @@ class Indexes(object):
         :param indexid: index id.
         :return: cnri, index_url
         """
-        index_url = url_for('invenio_search_ui.search',
-                            search_type=2, q=indexid, _external=True)
+        index_url = request.host_url.rstrip('/') + "/search?search_type=2&q=" + str(indexid)
         credential = PIDClientCredentials.load_from_JSON(
             current_app.config.get('WEKO_HANDLE_CREDS_JSON_PATH')
         )

--- a/modules/weko-index-tree/weko_index_tree/api.py
+++ b/modules/weko-index-tree/weko_index_tree/api.py
@@ -29,7 +29,7 @@ import traceback
 
 from b2handle.clientcredentials import PIDClientCredentials
 from redis.exceptions import RedisError
-from flask import current_app, json, request
+from flask import current_app, json, request, url_for
 from flask_babelex import gettext as _
 from flask_login import current_user
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -2086,7 +2086,8 @@ class Indexes(object):
         :param indexid: index id.
         :return: cnri, index_url
         """
-        index_url = request.url.split('/admin/')[0] + '/index/' + str(indexid)
+        index_url = url_for('invenio_search_ui.search',
+                            search_type=2, q=indexid, _external=True)
         credential = PIDClientCredentials.load_from_JSON(
             current_app.config.get('WEKO_HANDLE_CREDS_JSON_PATH')
         )


### PR DESCRIPTION
#53913

#### 修正概要 
index_urlの生成方法が間違っていたので修正した。

- api_appにweko_handleのextentionが読み込まれておらず、設定値を取得できなかったので読み込むように修正した。
- その際に、weko-handleのapi用のブループリントの名前が競合していたので名前を変更した。
（使われていないブループリントのようだったので影響はないと考えている。）

#### 動作確認
- handleの生成処理をコメントアウトした状態でインデックスを作成して、インデックスを表示できるURLが登録されることを確認した。（CNRIハンドルを登録できる環境がないため）

![image](https://github.com/user-attachments/assets/560bc5d3-4ab7-4865-b240-96e702674f99)
