### PR TITLE
Fix/ams login redirect

### DIFF
--- a/modules/weko-accounts/weko_accounts/views.py
+++ b/modules/weko-accounts/weko_accounts/views.py
@@ -561,7 +561,7 @@ def shib_sp_login():
         shib_session_id = request.form.get('Shib-Session-ID', None)
         if not shib_session_id and not _shib_enable:
             if ams_login:
-                return generate_ams_login_url(ams_error=_('Missing Shib-Session-ID!'))
+                return generate_ams_login_url(_('Missing Shib-Session-ID!'))
             else:
                 flash(_('Missing Shib-Session-ID!'), category='error')
                 return redirect(url_for_security('login'))
@@ -573,7 +573,7 @@ def shib_sp_login():
                 shib_attr.get('shib_eppn', None)
                 or _shib_username_config and shib_attr.get('shib_user_name')):
             if ams_login:
-                return generate_ams_login_url(ams_error=_('Missing SHIB_ATTRs!'))
+                return generate_ams_login_url(_('Missing SHIB_ATTRs!'))
             else:
                 flash(_('Missing SHIB_ATTRs!'), category='error')
                 return _redirect_method()
@@ -595,7 +595,7 @@ def shib_sp_login():
 
             if blocked:
                 if ams_login:
-                    return generate_ams_login_url(ams_error=_('Login is blocked.'))
+                    return generate_ams_login_url(_('Login is blocked.'))
                 else:
                     flash(_('Failed to login.'), category='error')
                     return _redirect_method()

--- a/modules/weko-accounts/weko_accounts/views.py
+++ b/modules/weko-accounts/weko_accounts/views.py
@@ -173,11 +173,15 @@ def generate_ams_login_url(ams_error):
     """
     Generate a redirect URL for the AMS login page with error details.
 
+    The returned URL starts with a '/'.
+
     Args:
-        ams_error (str): Error message describing the login error to include in the redirect URL.
+        ams_error (str): Error message for the AMS login page to include
+            in the redirect URL.
 
     Returns:
-        str: URL for the AMS login page including the error information as a query parameter.
+        str: URL for the AMS login page including the error
+            information as a query parameter.
     """
     shib_ams_login_url = current_app.config['WEKO_ACCOUNTS_SHIB_AMS_LOGIN_URL']
     ams_url = shib_ams_login_url.format('/')


### PR DESCRIPTION
- shib_sp_login()からlogin.pyに未病の画面のリダイレクトを返すと404になるため、URLを返すように修正
- confirm_user()でnextをrequest.argsではなくsessionから取得するように修正