### PR TITLE
未病のアクセス制御に関する単体テスト修正

### DIFF
--- a/modules/weko-accounts/tests/test_views.py
+++ b/modules/weko-accounts/tests/test_views.py
@@ -131,8 +131,7 @@ def test_redirect_method(app,mocker):
 
 # .tox/c1/bin/pytest --cov=weko_accounts tests/test_views.py::test_generate_ams_login_url -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_generate_ams_login_url(app):
-    url = 'ams'
-    with app.test_request_context(url):
+    with app.test_request_context():
         current_app.config['WEKO_ACCOUNTS_SHIB_AMS_LOGIN_URL'] = '{}ams/login'
         # Missing Shib-Session-ID!
         ams_error = 'Missing Shib-Session-ID!'

--- a/modules/weko-accounts/tests/test_views.py
+++ b/modules/weko-accounts/tests/test_views.py
@@ -27,7 +27,6 @@ def set_session(client,data):
             session[k] = v
 
 def del_session(client,key):
-
     with client.session_transaction() as session:
         del session[key]
 


### PR DESCRIPTION
generate_ams_login_url()の単体テストを新規作成
shib_sp_login()、confirm_user()の単体テストを修正
