### PR TITLE
fix: check and remove index before asserting non-existence

### DIFF
--- a/modules/invenio-indexer/tests/test_cli.py
+++ b/modules/invenio-indexer/tests/test_cli.py
@@ -78,6 +78,9 @@ def test_reindex(app, script_info):
 
         # Make sure the index doesn't exist at the beginning (it was not
         # preserved by accident from some other tests)
+        if current_search_client.indices.exists(index):
+            current_search_client.indices.delete(index=index)
+
         assert current_search_client.indices.exists(index) is False
 
         # Initialize queue


### PR DESCRIPTION
実行環境によってカバレッジに差異が生まれてしまっていたのを修正

リインデックスのテストで対象のインデックスが作成されていない必要があるが確認のみで削除していなかったため、削除して他のテストの影響を受けないように修正した。