### PR TITLE
fix broken test for weko-search-ui

### DIFF
--- a/modules/weko-search-ui/tests/test_query.py
+++ b/modules/weko-search-ui/tests/test_query.py
@@ -121,14 +121,14 @@ def test_get_permission_filter(i18n_app, users, client_request_args, indices):
     with patch("flask_login.utils._get_user", return_value=users[3]['obj']):
         with patch("weko_index_tree.api.Indexes.get_browsing_tree_paths", return_value=["33", "33/44"]):
             res = get_permission_filter(33)
-            expected = ([Terms(publish_status=['0', '1']), Terms(path=['33']), Bool(must=[Terms(publish_status=['0', '1']), Match(relation_version_is_last='true')])], 
+            expected = ([Terms(publish_status=['0', '1']), Terms(path=['33']), Bool(must=[Terms(publish_status=['0', '1']), Match(relation_version_is_last='true')])],
                         ['33','33/44'])
             assert res==expected
         mock_searchperm = MagicMock(side_effect=MockSearchPerm)
         with patch('weko_search_ui.query.search_permission', mock_searchperm):
             with patch("weko_index_tree.api.Indexes.get_browsing_tree_paths", return_value=["33", "33/44"]):
                 res = get_permission_filter()
-                expected = ([Bool(must=[Terms(path=['33', '44'])], should=[Bool(must=[Terms(publish_status=['0', '1']), Match(weko_creator_id='5')]), Bool(must=[Terms(publish_status=['0', '1']), Terms(weko_shared_ids=['5'])]), Bool(must=[Terms(publish_status=['0', '1'])])]), Bool(must=[Match(relation_version_is_last='true')])], 
+                expected = ([Bool(must=[Terms(path=['33', '44'])], should=[Bool(must=[Terms(publish_status=['0', '1']), Match(weko_creator_id='5')]), Bool(must=[Terms(publish_status=['0', '1']), Terms(weko_shared_ids=['5'])]), Bool(must=[Terms(publish_status=['0', '1'])])]), Bool(must=[Match(relation_version_is_last='true')])],
                             ['33','33/44'])
                 assert res==expected
 
@@ -156,13 +156,13 @@ def test_get_permission_filter_fulltext(i18n_app, users, client_request_args_FUL
     with patch("flask_login.utils._get_user", return_value=users[3]['obj']):
         with patch("weko_index_tree.api.Indexes.get_browsing_tree_paths", return_value=["33", "33/44", "66"]):
             res = get_permission_filter(33)
-            assert res==([Terms(publish_status=['0', '1']), Bool(should=[Terms(path=['33'])]), Bool(must=[Terms(publish_status=['0', '1']), Match(relation_version_is_last='true')])], 
+            assert res==([Terms(publish_status=['0', '1']), Bool(should=[Terms(path=['33'])]), Bool(must=[Terms(publish_status=['0', '1']), Match(relation_version_is_last='true')])],
                          ['33','33/44', '66'])
         mock_searchperm = MagicMock(side_effect=MockSearchPerm)
         with patch('weko_search_ui.query.search_permission', mock_searchperm):
             with patch("weko_index_tree.api.Indexes.get_browsing_tree_paths", return_value=["33", "33/44", "66"]):
                 res = get_permission_filter()
-                assert res==([Bool(must=[Terms(path=['33','44', '66'])], should=[Bool(must=[Terms(publish_status=['0', '1']), Match(weko_creator_id='5')]), Bool(must=[Terms(publish_status=['0', '1']), Terms(weko_shared_ids=['5'])]), Bool(must=[Terms(publish_status=['0', '1'])])]), Bool(must=[Match(relation_version_is_last='true')])], 
+                assert res==([Bool(must=[Terms(path=['33','44', '66'])], should=[Bool(must=[Terms(publish_status=['0', '1']), Match(weko_creator_id='5')]), Bool(must=[Terms(publish_status=['0', '1']), Terms(weko_shared_ids=['5'])]), Bool(must=[Terms(publish_status=['0', '1'])])]), Bool(must=[Match(relation_version_is_last='true')])],
                         ['33','33/44', '66'])
 
 
@@ -237,7 +237,7 @@ def test_default_search_factory(app, users, communities):
                 app.extensions['invenio-queues'] = 1
                 res = default_search_factory(self=None, search=search)
                 query = (res[0].query()).to_dict()
-                assert query == {"query": {"bool": {"filter": [{"bool": {"must": [{"bool": {"should": [{"bool": {"must": [{"terms": {"publish_status": ["0", "1"]}}, {"match": {"weko_creator_id": "5"}}]}}, {"bool": {"must": [{"terms": {"publish_status": ["0", "1"]}}, {"match": {"weko_shared_id": "5"}}]}}, {"bool": {"must": [{"terms": {"publish_status": ["0", "1"]}}]}}], "must": [{"terms": {"path": ["33", "44"]}}]}}, {"bool": {"must": [{"match": {"relation_version_is_last": "true"}}]}}, {"bool": {"should": [{"match": {"language": {"operator": "and", "query": "jpn"}}}, {"bool": {"filter": [{"script": {"script": {"source": "boolean flg=false; for(lang in doc['language']){if (!params.param1.contains(lang)){flg=true;}} return flg;", "params": {"param1": ["jpn", "eng", "fra", "ita", "deu", "spa", "zho", "rus", "lat", "msa", "epo", "ara", "ell", "kor", "other"]}}}}]}}]}}, {"bool": {"should": [{"nested": {"path": "relation.relatedIdentifier", "query": {"bool": {"must": [{"match": {"relation.relatedIdentifier.value": {"operator": "and", "query": "1"}}}, {"term": {"relation.relatedIdentifier.identifierType": "identifier"}}]}}}}]}}, {"bool": {"should": [{"nested": {"path": "content", "query": {"bool": {"must": [{"terms": {"content.licensetype.raw": ["test_license"]}}]}}}}]}}, {"nested": {"path": "file.date", "query": {"bool": {"should": [{"term": {"file.date.dateType": "Accepted"}}], "must": [{"range": {"file.date.value": {"gte": "2022-10-01", "lte": "2022-10-30"}}}]}}}}, {"range": {"date_range1": {"gte": "2022-10-01", "lte": "2022-10-30"}}}, {"match": {"text1": {"operator": "and", "query": "test_text"}}}]}}], "must": [{"match_all": {}}]}}, "_source": {"excludes": ["content"]}}
+                assert query == {"query": {"bool": {"filter": [{"bool": {"must": [{"bool": {"should": [{"bool": {"must": [{"terms": {"publish_status": ["0", "1"]}}, {"match": {"weko_creator_id": "5"}}]}}, {"bool": {"must": [{"terms": {"publish_status": ["0", "1"]}}, {"terms": {"weko_shared_ids": ["5"]}}]}}, {"bool": {"must": [{"terms": {"publish_status": ["0", "1"]}}]}}], "must": [{"terms": {"path": ["33", "44"]}}]}}, {"bool": {"must": [{"match": {"relation_version_is_last": "true"}}]}}, {"bool": {"should": [{"match": {"language": {"operator": "and", "query": "jpn"}}}, {"bool": {"filter": [{"script": {"script": {"source": "boolean flg=false; for(lang in doc['language']){if (!params.param1.contains(lang)){flg=true;}} return flg;", "params": {"param1": ["jpn", "eng", "fra", "ita", "deu", "spa", "zho", "rus", "lat", "msa", "epo", "ara", "ell", "kor", "other"]}}}}]}}]}}, {"bool": {"should": [{"nested": {"path": "relation.relatedIdentifier", "query": {"bool": {"must": [{"match": {"relation.relatedIdentifier.value": {"operator": "and", "query": "1"}}}]}}}}]}}, {"bool": {"should": [{"nested": {"path": "content", "query": {"bool": {"must": [{"terms": {"content.licensetype.raw": ["test_license"]}}]}}}}]}}, {"nested": {"path": "file.date", "query": {"bool": {"should": [{"term": {"file.date.dateType": "Accepted"}}], "must": [{"range": {"file.date.value": {"gte": "2022-10-01", "lte": "2022-10-30"}}}]}}}}, {"range": {"date_range1": {"gte": "2022-10-01", "lte": "2022-10-30"}}}, {"match": {"text1": {"operator": "and", "query": "test_text"}}}]}}], "must": [{"match_all": {}}]}}, "_source": {"excludes": ["content"]}}
 
 
         mock_searchperm = MagicMock(side_effect=MockSearchPerm)
@@ -245,7 +245,7 @@ def test_default_search_factory(app, users, communities):
             with patch('invenio_records_rest.facets.default_facets_factory', side_effect=lambda x,y: (x, MultiDict([]))):
 
                 EXPECT0 = {'bool': {'should': [{'bool': {'must': [{'terms': {'publish_status': ['0', '1']}}, {'match': {'weko_creator_id': None}}]}},
-                                               {'bool': {'must': [{'terms': {'publish_status': ['0', '1']}}, {'match': {'weko_shared_id': None}}]}},
+                                               {'bool': {'must': [{'terms': {'publish_status': ['0', '1']}}, {'terms': {'weko_shared_ids': [None]}}]}},
                                                {'bool': {'must': [{'terms': {'publish_status': ['0']}},
                                                                   {'range': {'publish_date': {'lte': 'now/d', 'time_zone': 'UTC'}}}]}}],
                                     'must': [{'terms': {'path': []}}]}}
@@ -381,12 +381,9 @@ def test_default_search_factory(app, users, communities):
                             }
                         }
                     }
-                    expect_0 = {
-                        "exists": { "field": "identifierRegistration.identifierType" }
-                    }
                     nested_query = copy.deepcopy(NESTED_QUERY_TEMPLATE)
                     nested_query["nested"]["path"] = "identifierRegistration"
-                    nested_query["nested"]["query"]["bool"] = {"must":[expect_1, expect_0]}
+                    nested_query["nested"]["query"]["bool"] = {"must":[expect_1]}
                     expect = {"bool": {"should":[nested_query]}}
 
                     search_query, _ = default_search_factory(self=None, search=search)
@@ -400,7 +397,6 @@ def test_default_search_factory(app, users, communities):
                     nested_query = copy.deepcopy(NESTED_QUERY_TEMPLATE)
                     nested_query["nested"]["path"] = "identifierRegistration"
                     nested_query["nested"]["query"]["bool"] = {
-                        "must": [expect_0],
                         "should": [expect_1, expect_2],
                         "minimum_should_match": 1
                     }
@@ -601,7 +597,7 @@ def test_default_search_factory_no_queries(app, users, communities):
             with patch('invenio_records_rest.facets.default_facets_factory', side_effect=lambda x,y: (x, MultiDict([]))):
 
                 EXPECT0 = {'bool': {'should': [{'bool': {'must': [{'terms': {'publish_status': ['0', '1']}}, {'match': {'weko_creator_id': None}}]}},
-                                                {'bool': {'must': [{'terms': {'publish_status': ['0', '1']}}, {'match': {'weko_shared_id': None}}]}},
+                                                {'bool': {'must': [{'terms': {'publish_status': ['0', '1']}}, {'terms': {'weko_shared_ids': [None]}}]}},
                                                 {'bool': {'must': [{'terms': {'publish_status': ['0']}},
                                                     {'range': {'publish_date': {'lte': 'now/d', 'time_zone': 'UTC'}}}]}}],
                     'must': [{'terms': {'path': []}}]}}


### PR DESCRIPTION
テストの期待結果修正

関連コミット
- weko_shared_idからweko_shared_idsへ変更 a6be4a94da1cf119887eb66814f685390d2b0b53

- 「identifier」タイプの検索時に「identifier type」を無視して、値のみで検索 b7a6e53eee39cc3031651b00681f8b5b181a5c24