### PR TITLE
add temporary workaround of custom_sort order

### DIFF
--- a/modules/invenio-records-rest/invenio_records_rest/views.py
+++ b/modules/invenio-records-rest/invenio_records_rest/views.py
@@ -945,9 +945,9 @@ class RecordsListResource(ContentNegotiatedMethodView):
             ), reverse=not is_asc
         )
 
-        total = len(sorted_result)
-        start = total - (page - 1) * size
-        end = total - page * size
+        start = (page - 1) * size
+        end = page * size
+        #prependの修正をする際に[end:start]から[start:end]に修正が必要
         sorted_hits = [hit for _, hit in sorted_result[end:start]]
         search_result_dict["hits"]["hits"] = sorted_hits
 

--- a/modules/invenio-records-rest/invenio_records_rest/views.py
+++ b/modules/invenio-records-rest/invenio_records_rest/views.py
@@ -947,7 +947,9 @@ class RecordsListResource(ContentNegotiatedMethodView):
 
         start = (page - 1) * size
         end = page * size
-        #prependの修正をする際に[end:start]から[start:end]に修正が必要
+        # The order is reversed by the `prepend` method in 
+        # `weko_records.serializers.feed:WekoFeedGenerator.add_entry`. 
+        # As a temporary workaround, change `[end:start]` to `[start:end]`.
         sorted_hits = [hit for _, hit in sorted_result[end:start]]
         search_result_dict["hits"]["hits"] = sorted_hits
 

--- a/modules/invenio-records-rest/invenio_records_rest/views.py
+++ b/modules/invenio-records-rest/invenio_records_rest/views.py
@@ -952,7 +952,8 @@ class RecordsListResource(ContentNegotiatedMethodView):
         flag = "prepend"
         start, end = (page - 1) * size, page * size
         sorted_hits = [hit for _, hit in sorted_result[start:end]]
-        search_result_dict["hits"]["hits"] = sorted_hits if flag == "append" else list(reversed(sorted_hits))
+        sorted_hits2 = sorted_hits.reverse()
+        search_result_dict["hits"]["hits"] = sorted_hits if flag == "append" else sorted_hits2
 
     @classmethod
     def _customsort_priority(cls, hit, target_index, is_asc, custom_sort):

--- a/modules/invenio-records-rest/invenio_records_rest/views.py
+++ b/modules/invenio-records-rest/invenio_records_rest/views.py
@@ -952,8 +952,9 @@ class RecordsListResource(ContentNegotiatedMethodView):
         flag = "prepend"
         start, end = (page - 1) * size, page * size
         sorted_hits = [hit for _, hit in sorted_result[start:end]]
-        sorted_hits2 = sorted_hits.reverse()
-        search_result_dict["hits"]["hits"] = sorted_hits if flag == "append" else sorted_hits2
+        if flag == "prepend":
+             sorted_hits.reverse()
+        search_result_dict["hits"]["hits"] = sorted_hits
 
     @classmethod
     def _customsort_priority(cls, hit, target_index, is_asc, custom_sort):

--- a/modules/invenio-records-rest/invenio_records_rest/views.py
+++ b/modules/invenio-records-rest/invenio_records_rest/views.py
@@ -945,9 +945,10 @@ class RecordsListResource(ContentNegotiatedMethodView):
             ), reverse=not is_asc
         )
 
-        start = (page - 1) * size
-        end = page * size
-        sorted_hits = [hit for _, hit in sorted_result[start:end]]
+        total = len(sorted_result)
+        start = total - (page - 1) * size
+        end = total - page * size
+        sorted_hits = [hit for _, hit in sorted_result[end:start]]
         search_result_dict["hits"]["hits"] = sorted_hits
 
     @classmethod

--- a/modules/invenio-records-rest/invenio_records_rest/views.py
+++ b/modules/invenio-records-rest/invenio_records_rest/views.py
@@ -975,7 +975,6 @@ class RecordsListResource(ContentNegotiatedMethodView):
         path = min(paths) if is_asc else max(paths)
         if path not in custom_sort:
             index_custom_sort = Indexes.get_item_sort(path)
-            print("ソート",index_custom_sort)
             if index_custom_sort:
                 custom_sort[path] = index_custom_sort
 

--- a/modules/invenio-records-rest/invenio_records_rest/views.py
+++ b/modules/invenio-records-rest/invenio_records_rest/views.py
@@ -899,10 +899,10 @@ class RecordsListResource(ContentNegotiatedMethodView):
         Args:
             search(invenio_search.api.RecordsSearch): search query
             is_asc(boolean): Whether to sort in ascending or descending order.
-        
+
         Returns:
             search(invenio_search.api.RecordsSearch): search query with added sort
-            
+
         """
         search = search[0:self.max_result_window]
         search._sort = []
@@ -945,13 +945,14 @@ class RecordsListResource(ContentNegotiatedMethodView):
             ), reverse=not is_asc
         )
 
-        start = (page - 1) * size
-        end = page * size
-        # The order is reversed by the `prepend` method in 
-        # `weko_records.serializers.feed:WekoFeedGenerator.add_entry`. 
-        # As a temporary workaround, change `[end:start]` to `[start:end]`.
-        sorted_hits = [hit for _, hit in sorted_result[end:start]]
-        search_result_dict["hits"]["hits"] = sorted_hits
+        # The order is reversed by the `prepend` method in
+        # `weko_records.serializers.feed:WekoFeedGenerator.add_entry`.
+        # As a temporary workaround,  set to “prepend,” reverse the order.
+        # When it changes to “append,” please remove the flag and the if statement.
+        flag = "prepend"
+        start, end = (page - 1) * size, page * size
+        sorted_hits = [hit for _, hit in sorted_result[start:end]]
+        search_result_dict["hits"]["hits"] = sorted_hits if flag == "append" else list(reversed(sorted_hits))
 
     @classmethod
     def _customsort_priority(cls, hit, target_index, is_asc, custom_sort):
@@ -974,6 +975,7 @@ class RecordsListResource(ContentNegotiatedMethodView):
         path = min(paths) if is_asc else max(paths)
         if path not in custom_sort:
             index_custom_sort = Indexes.get_item_sort(path)
+            print("ソート",index_custom_sort)
             if index_custom_sort:
                 custom_sort[path] = index_custom_sort
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,2 @@
+a = list(range(100))
+print(a)

--- a/test.py
+++ b/test.py
@@ -1,2 +1,0 @@
-a = list(range(100))
-print(a)


### PR DESCRIPTION
The order is reversed by the `prepend` method in
`weko_records.serializers.feed:WekoFeedGenerator.add_entry`.
As a temporary workaround,  set to “prepend,” reverse the order.