### PR TITLE
fix handling file_download_permission / unit tests

### DIFF
--- a/modules/weko-records-ui/tests/test_permissions.py
+++ b/modules/weko-records-ui/tests/test_permissions.py
@@ -95,6 +95,11 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
+        fjson_no_date = fjson.copy()
+        del fjson_no_date['date']
+        assert check_file_download_permission(record, fjson_no_date, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
         fjson_no_dateValue = fjson.copy()
         del fjson_no_dateValue['date'][0]['dateValue']
 
@@ -124,6 +129,12 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
         assert download_status['is_open_access'] == True
 
         fjson['accessrole'] = 'open_date'
+
+        fjson_no_date = fjson.copy()
+        del fjson_no_date['date']
+        assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
@@ -156,6 +167,12 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
         fjson['date'][0]['dateValue'] = "2022-09-27"
         fjson['accessrole'] = 'open_date'
+
+        fjson_no_date = fjson.copy()
+        del fjson_no_date['date']
+        assert check_file_download_permission(record, fjson_no_date, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
 
         assert check_file_download_permission(record, fjson, True) == True
 

--- a/modules/weko-records-ui/tests/test_permissions.py
+++ b/modules/weko-records-ui/tests/test_permissions.py
@@ -82,31 +82,47 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
     # login Super users (repository admin)
     with patch("flask_login.utils._get_user", return_value=users[1]["obj"]):
+        # open access and past date
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
+        fjson['date'][0]['dateValue'] = "2100-09-27"
+        # open access and future date
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
         fjson_no_date = fjson.copy()
         del fjson_no_date['date']
-
+        # open access and no date
         assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
+        # open access and no dateValue
+        fjson_no_dateValue = fjson.copy()
+        del fjson_no_dateValue['date'][0]['dateValue']
+        assert check_file_download_permission(record, fjson_no_dateValue, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
+        fjson['date'][0]['dateValue'] = "2022-09-27"
         fjson['accessrole'] = 'open_date'
+        # open date access and past date
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
         fjson_no_date = fjson.copy()
         del fjson_no_date['date']
+        # open date access and no date
         assert check_file_download_permission(record, fjson_no_date, False, download_status=download_status) == True
         assert download_status['is_open_access'] == False
 
         fjson_no_dateValue = fjson.copy()
         del fjson_no_dateValue['date'][0]['dateValue']
-
+        # open date access and no dateValue
         assert check_file_download_permission(record, fjson_no_dateValue, True, download_status=download_status) == True
         assert download_status['is_open_access'] == False
 
         fjson['date'][0]['dateValue'] = "2100-09-27"
+        # open date access and future date
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == False
 
@@ -121,24 +137,47 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
         fjson_no_date = fjson.copy()
         del fjson_no_date['date']
-
+        # open access and no date
         assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
-        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
-        assert download_status['is_open_access'] == True
-
-        fjson['accessrole'] = 'open_date'
-
-        fjson_no_date = fjson.copy()
-        del fjson_no_date['date']
-        assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
-        assert download_status['is_open_access'] == False
-
+        # open access and past date
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
         fjson['date'][0]['dateValue'] = "2100-09-27"
+        # open access and future date
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+        fjson_no_dateValue = fjson.copy()
+        del fjson_no_dateValue['date'][0]['dateValue']
+        # open access and no dateValue
+        assert check_file_download_permission(record, fjson_no_dateValue, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
+        fjson['date'][0]['dateValue'] = "2022-09-27"
+        fjson['accessrole'] = 'open_date'
+
+        fjson_no_date = fjson.copy()
+        del fjson_no_date['date']
+        # open date access and no date
+        assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+        # open date access and past date
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
+        fjson_no_dateValue = fjson.copy()
+        del fjson_no_dateValue['date'][0]['dateValue']
+
+        # open date access and no dateValue
+        assert check_file_download_permission(record, fjson_no_dateValue, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+        fjson['date'][0]['dateValue'] = "2100-09-27"
+        # open date access and future date
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == False
 
@@ -148,28 +187,52 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
     fjson['accessrole'] = 'open_access'
     fjson['date'][0]['dateValue'] = "2022-09-27"
-    # # login Contributor
+    # login Contributor
     with patch("flask_login.utils._get_user", return_value=users[0]["obj"]):
-        assert check_file_download_permission(record, fjson, True) == True
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
 
-    with patch("flask_login.utils._get_user", return_value=users[0]["obj"]):
+        # open access and past date
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
+        fjson['date'][0]['dateValue'] = "2100-09-27"
+        # open access and future date
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == False
+        assert download_status['is_open_access'] == False
 
         fjson_no_date = fjson.copy()
         del fjson_no_date['date']
+        # open access and no date
+        assert check_file_download_permission(record, fjson_no_date, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
 
-        assert check_file_download_permission(record, fjson_no_date, False) == True
-
-        assert check_file_download_permission(record, fjson, False) == True
-
-        fjson['date'][0]['dateValue'] = ""
-        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
+        fjson_no_dateValue = fjson.copy()
+        del fjson_no_dateValue['date'][0]['dateValue']
+        # open access and no dateValue
+        assert check_file_download_permission(record, fjson_no_dateValue, False, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
         fjson['date'][0]['dateValue'] = "2022-09-27"
         fjson['accessrole'] = 'open_date'
+        # open date access and past date
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
+        fjson['date'][0]['dateValue'] = "2100-09-27"
+        # open date access and future date
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == False
+        assert download_status['is_open_access'] == False
+
+        fjson_no_dateValue = fjson.copy()
+        del fjson_no_dateValue['date'][0]['dateValue']
+        # open date access and no dateValue
+        assert check_file_download_permission(record, fjson_no_dateValue, False, download_status=download_status) == False
+        assert download_status['is_open_access'] == False
 
         fjson_no_date = fjson.copy()
         del fjson_no_date['date']
+        # open date access and no date
         assert check_file_download_permission(record, fjson_no_date, False, download_status=download_status) == True
         assert download_status['is_open_access'] == False
 
@@ -178,15 +241,6 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == False
-
-        assert check_file_download_permission(record, fjson, False) == True
-
-        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
-        assert download_status['is_open_access'] == True
-
-
-        fjson['date'][0]['dateValue'] = "2100-09-27"
-        assert check_file_download_permission(record, fjson, False) == False
 
         fjson['accessrole'] = 'open_login'
         assert check_file_download_permission(record, fjson, True) == True

--- a/modules/weko-records-ui/tests/test_permissions.py
+++ b/modules/weko-records-ui/tests/test_permissions.py
@@ -79,24 +79,25 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
     record = results[0]["record"]
     fjson = {'url': {'url': 'https://weko3.example.org/record/11/files/001.jpg'}, 'date': [{'dateType': 'Available', 'dateValue': '2022-09-27'}], 'format': 'image/jpeg', 'filename': 'helloworld.pdf', 'filesize': [{'value': '2.7 MB'}], 'accessrole': 'open_access', 'version_id': 'd73bd9cb-aa9e-4cd0-bf07-c5976d40bdde', 'displaytype': 'preview', 'is_thumbnail': False, 'future_date_message': '', 'download_preview_message': '', 'size': 2700000.0, 'mimetype': 'image/jpeg', 'file_order': 0}
     download_status = {}
-    
+
+    # login Super users (repository admin)
     with patch("flask_login.utils._get_user", return_value=users[1]["obj"]):
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
-        
+
         fjson_no_date = fjson.copy()
         del fjson_no_date['date']
 
         assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
-        assert download_status['is_open_access'] == None
+        assert download_status['is_open_access'] == True
 
         fjson['accessrole'] = 'open_date'
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
-        
+
         fjson_no_dateValue = fjson.copy()
         del fjson_no_dateValue['date'][0]['dateValue']
-        
+
         assert check_file_download_permission(record, fjson_no_dateValue, True, download_status=download_status) == True
         assert download_status['is_open_access'] == False
 
@@ -110,7 +111,15 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
     fjson['accessrole'] = 'open_access'
     fjson['date'][0]['dateValue'] = "2022-09-27"
+    # login Registered user
     with patch("flask_login.utils._get_user", return_value=users[7]["obj"]):
+
+        fjson_no_date = fjson.copy()
+        del fjson_no_date['date']
+
+        assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
         assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
         assert download_status['is_open_access'] == True
 
@@ -128,21 +137,37 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
     fjson['accessrole'] = 'open_access'
     fjson['date'][0]['dateValue'] = "2022-09-27"
+    # # login Contributor
     with patch("flask_login.utils._get_user", return_value=users[0]["obj"]):
         assert check_file_download_permission(record, fjson, True) == True
-    
+
     with patch("flask_login.utils._get_user", return_value=users[0]["obj"]):
+
+        fjson_no_date = fjson.copy()
+        del fjson_no_date['date']
+
+        assert check_file_download_permission(record, fjson_no_date, False) == True
+
         assert check_file_download_permission(record, fjson, False) == True
-        
+
         fjson['date'][0]['dateValue'] = ""
         assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
         assert download_status['is_open_access'] == True
-        
+
         fjson['date'][0]['dateValue'] = "2022-09-27"
         fjson['accessrole'] = 'open_date'
+
         assert check_file_download_permission(record, fjson, True) == True
+
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
         assert check_file_download_permission(record, fjson, False) == True
-        
+
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
+
         fjson['date'][0]['dateValue'] = "2100-09-27"
         assert check_file_download_permission(record, fjson, False) == False
 
@@ -163,7 +188,7 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
 
         fjson['accessrole'] = 'open_restricted'
         assert check_file_download_permission(record, fjson, True) == False
-            
+
 
     itn = ItemTypeName(
         id=1, name="テストアイテムタイプ", has_site_license=False, is_active=True
@@ -199,12 +224,12 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
                 # 8
                 with patch("weko_records_ui.utils.is_future", return_value=True):
                     assert check_file_download_permission(record_a, fjson_a, check_billing_file=True, download_status=download_status) == True
-                # 10 
+                # 10
                 with patch("weko_records_ui.utils.is_future", return_value=False):
                     assert check_file_download_permission(record_b, fjson_b, check_billing_file=True, download_status=download_status) == True
                 # 12
-                assert check_file_download_permission(record_c, fjson_c, check_billing_file=True) == True  
-                
+                assert check_file_download_permission(record_c, fjson_c, check_billing_file=True) == True
+
 
             # 課金ファイルアクセス権なし
             with patch("weko_records_ui.permissions.check_billing_file_permission", return_value=False):
@@ -216,7 +241,7 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
                     assert check_file_download_permission(record_b, fjson_b, check_billing_file=True, download_status=download_status) == True
                 # 13
                 assert check_file_download_permission(record_c, fjson_c, check_billing_file=True) == False
-                
+
 
 # def check_open_restricted_permission(record, fjson):
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_permissions.py::test_check_open_restricted_permission -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
@@ -229,10 +254,10 @@ def test_check_open_restricted_permission(app, records, users,db_file_permission
 
     with patch("flask_login.utils._get_user", return_value=users[1]["obj"]):
         assert check_open_restricted_permission(record, fjson) == False
-        
+
         with patch("weko_records_ui.permissions.__get_file_permission", return_value=data1):
             assert check_open_restricted_permission(record, fjson) == False
-            
+
 
 # def is_open_restricted(file_data):
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_permissions.py::test_get_permission -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp
@@ -302,7 +327,7 @@ def test_get_permission(app, records, users,db_file_permission):
             data1.status = 0
             with patch("weko_workflow.api.WorkActivity.get_activity_steps", return_value=[data2]):
                 assert get_permission(record, fjson) == None
-            
+
             with patch("weko_workflow.api.WorkActivity.get_activity_steps", return_value=""):
                 assert get_permission(record, fjson) != None
 
@@ -398,8 +423,8 @@ def test_check_publish_status(app):
             "%Y-%m-%d"
         )
         assert check_publish_status(record) == True
-        
-        
+
+
         record["publish_status"] = "1"
         record["pubdate"]["attribute_value"] = now.strftime("%Y-%m-%d")
         assert record.get("publish_status") == "1"
@@ -853,7 +878,7 @@ def test_check_billing_file_permission(users, db_item_billing):
     with patch("flask_login.utils._get_user", return_value=users[1]["obj"]):
         with patch("weko_records_ui.permissions.check_charge", return_value='not_billed'):
             assert check_billing_file_permission('1', '課金ファイル.txt') == True
-    # 25 
+    # 25
     with patch("flask_login.utils._get_user", return_value=users[2]["obj"]):
         with patch("weko_records_ui.permissions.check_charge", return_value='not_billed'):
             assert check_billing_file_permission('1', '課金ファイル.txt') == False

--- a/modules/weko-records-ui/tests/test_permissions.py
+++ b/modules/weko-records-ui/tests/test_permissions.py
@@ -78,47 +78,91 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
     indexer, results = records
     record = results[0]["record"]
     fjson = {'url': {'url': 'https://weko3.example.org/record/11/files/001.jpg'}, 'date': [{'dateType': 'Available', 'dateValue': '2022-09-27'}], 'format': 'image/jpeg', 'filename': 'helloworld.pdf', 'filesize': [{'value': '2.7 MB'}], 'accessrole': 'open_access', 'version_id': 'd73bd9cb-aa9e-4cd0-bf07-c5976d40bdde', 'displaytype': 'preview', 'is_thumbnail': False, 'future_date_message': '', 'download_preview_message': '', 'size': 2700000.0, 'mimetype': 'image/jpeg', 'file_order': 0}
+    download_status = {}
+    
     with patch("flask_login.utils._get_user", return_value=users[1]["obj"]):
-        assert check_file_download_permission(record, fjson, True) == True
-    
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+        
+        fjson_no_date = fjson.copy()
+        del fjson_no_date['date']
+
+        assert check_file_download_permission(record, fjson_no_date, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == None
+
+        fjson['accessrole'] = 'open_date'
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+        
+        fjson_no_dateValue = fjson.copy()
+        del fjson_no_dateValue['date'][0]['dateValue']
+        
+        assert check_file_download_permission(record, fjson_no_dateValue, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+        fjson['date'][0]['dateValue'] = "2100-09-27"
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+        fjson['accessrole'] = 'open_login'
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+    fjson['accessrole'] = 'open_access'
+    fjson['date'][0]['dateValue'] = "2022-09-27"
     with patch("flask_login.utils._get_user", return_value=users[7]["obj"]):
-        assert check_file_download_permission(record, fjson, True) == True
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
 
+        fjson['accessrole'] = 'open_date'
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+
+        fjson['date'][0]['dateValue'] = "2100-09-27"
+        assert check_file_download_permission(record, fjson, True, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+        fjson['accessrole'] = 'open_login'
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == False
+
+    fjson['accessrole'] = 'open_access'
+    fjson['date'][0]['dateValue'] = "2022-09-27"
     with patch("flask_login.utils._get_user", return_value=users[0]["obj"]):
         assert check_file_download_permission(record, fjson, True) == True
     
     with patch("flask_login.utils._get_user", return_value=users[0]["obj"]):
-        with patch("weko_records_ui.permissions.to_utc", return_value=datetime.now()):
-            assert check_file_download_permission(record, fjson, False) == False
-            
-            fjson['date'][0]['dateValue'] = ""
+        assert check_file_download_permission(record, fjson, False) == True
+        
+        fjson['date'][0]['dateValue'] = ""
+        assert check_file_download_permission(record, fjson, False, download_status=download_status) == True
+        assert download_status['is_open_access'] == True
+        
+        fjson['date'][0]['dateValue'] = "2022-09-27"
+        fjson['accessrole'] = 'open_date'
+        assert check_file_download_permission(record, fjson, True) == True
+        assert check_file_download_permission(record, fjson, False) == True
+        
+        fjson['date'][0]['dateValue'] = "2100-09-27"
+        assert check_file_download_permission(record, fjson, False) == False
+
+        fjson['accessrole'] = 'open_login'
+        assert check_file_download_permission(record, fjson, True) == True
+
+        with patch("weko_records_ui.permissions.check_user_group_permission", return_value=True):
+            fjson['groups'] = True
             assert check_file_download_permission(record, fjson, False) == True
-            
-            fjson['date'][0]['dateValue'] = "2022-09-27"
-            fjson['accessrole'] = 'open_date'
-            assert check_file_download_permission(record, fjson, True) == True
-            assert check_file_download_permission(record, fjson, False) == False
+            fjson['groups'] = False
+            assert check_file_download_permission(record, fjson, False) == True
+            fjson['groupsprice'] = [MagicMock()]
+            assert check_file_download_permission(record, fjson, False) == True
 
-            with patch("weko_records_ui.permissions.to_utc", return_value="test"):
-                assert check_file_download_permission(record, fjson, False) == False
-            
-            fjson['accessrole'] = 'open_login'
-            assert check_file_download_permission(record, fjson, True) == True
+        fjson['accessrole'] = 'open_no'
+        assert check_file_download_permission(record, fjson, True) == False
+        assert check_file_download_permission(record, fjson, False) == False
 
-            with patch("weko_records_ui.permissions.check_user_group_permission", return_value=True):
-                fjson['groups'] = True
-                assert check_file_download_permission(record, fjson, False) == True
-                fjson['groups'] = False
-                assert check_file_download_permission(record, fjson, False) == True
-                fjson['groupsprice'] = [MagicMock()]
-                assert check_file_download_permission(record, fjson, False) == True
-    
-            fjson['accessrole'] = 'open_no'
-            assert check_file_download_permission(record, fjson, True) == False
-            assert check_file_download_permission(record, fjson, False) == False
-
-            fjson['accessrole'] = 'open_restricted'
-            assert check_file_download_permission(record, fjson, True) == False
+        fjson['accessrole'] = 'open_restricted'
+        assert check_file_download_permission(record, fjson, True) == False
             
 
     itn = ItemTypeName(
@@ -127,8 +171,6 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
     obj = ItemType(
         item_type_name=itn
         )
-    future_date = datetime(2023,12,31,15,0,0)
-    past_date = datetime(2022,11,30,15,0,0)
 
     with open("tests/data/record_a.json","r") as fa:
         record_a = json.load(fa)
@@ -155,40 +197,26 @@ def test_check_file_download_permission(app, records, users,db_file_permission):
             # 課金ファイルアクセス権あり
             with patch("weko_records_ui.permissions.check_billing_file_permission", return_value=True):
                 # 8
-                with patch("weko_records_ui.permissions.to_utc", return_value=future_date):
-                    assert check_file_download_permission(record_a, fjson_a, check_billing_file=True) == True
-                # 10
-                with patch("weko_records_ui.permissions.to_utc", return_value=past_date):
-                    assert check_file_download_permission(record_b, fjson_b, check_billing_file=True) == True
+                with patch("weko_records_ui.utils.is_future", return_value=True):
+                    assert check_file_download_permission(record_a, fjson_a, check_billing_file=True, download_status=download_status) == True
+                # 10 
+                with patch("weko_records_ui.utils.is_future", return_value=False):
+                    assert check_file_download_permission(record_b, fjson_b, check_billing_file=True, download_status=download_status) == True
                 # 12
-                assert check_file_download_permission(record_c, fjson_c, check_billing_file=True) == True
-                # 14
-                with patch("weko_records_ui.permissions.to_utc", return_value=future_date):
-                    assert check_file_download_permission(record_a, fjson_a, check_billing_file=False) == False
-                # 16
-                with patch("weko_records_ui.permissions.to_utc", return_value=past_date):
-                    assert check_file_download_permission(record_b, fjson_b, check_billing_file=False) == True
-                # 18
-                assert check_file_download_permission(record_c, fjson_c, check_billing_file=False) == True
+                assert check_file_download_permission(record_c, fjson_c, check_billing_file=True) == True  
+                
 
             # 課金ファイルアクセス権なし
             with patch("weko_records_ui.permissions.check_billing_file_permission", return_value=False):
                 # 9
-                with patch("weko_records_ui.permissions.to_utc", return_value=future_date):
-                    assert check_file_download_permission(record_a, fjson_a, check_billing_file=True) == False
+                with patch("weko_records_ui.utils.is_future", return_value=True):
+                    assert check_file_download_permission(record_a, fjson_a, check_billing_file=True, download_status=download_status) == False
                 # 11
-                with patch("weko_records_ui.permissions.to_utc", return_value=past_date):
-                    assert check_file_download_permission(record_b, fjson_b, check_billing_file=True) == True
+                with patch("weko_records_ui.utils.is_future", return_value=False):
+                    assert check_file_download_permission(record_b, fjson_b, check_billing_file=True, download_status=download_status) == True
                 # 13
                 assert check_file_download_permission(record_c, fjson_c, check_billing_file=True) == False
-                # 15
-                with patch("weko_records_ui.permissions.to_utc", return_value=future_date):
-                    assert check_file_download_permission(record_a, fjson_a, check_billing_file=False) == False
-                # 17
-                with patch("weko_records_ui.permissions.to_utc", return_value=past_date):
-                    assert check_file_download_permission(record_b, fjson_b, check_billing_file=False) == True
-                # 19
-                assert check_file_download_permission(record_c, fjson_c, check_billing_file=False) == True
+                
 
 # def check_open_restricted_permission(record, fjson):
 # .tox/c1/bin/pytest --cov=weko_records_ui tests/test_permissions.py::test_check_open_restricted_permission -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-records-ui/.tox/c1/tmp

--- a/modules/weko-records-ui/weko_records_ui/permissions.py
+++ b/modules/weko-records-ui/weko_records_ui/permissions.py
@@ -112,15 +112,19 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
         return emails
 
     def _is_open_date_past(acsrole):
-        """ Check the open date has passed.
-    
+        """Check if file is open access by open date.
+
+        This value is decide whether display this file as open access or not.
+        If the file has open date, return if the open date is past or not.
+        If the open date is past, return file's access role is open access or not.
+
         Args:
             acsrole (str): File permission
-        
+
         Returns:
-            bool: 
-                True if the open date passed, or dateValue is None and file permission is open access.
-                False if the open date has not passed, or dateValue is None and file permission is open date.
+            bool: True if the file is open access, False otherwise.
+
+
         """
         from .utils import is_future
         date = fjson.get('date')
@@ -128,12 +132,8 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
             adt = date[0].get('dateValue')
             if adt:
                 return not is_future(adt)
-            elif acsrole == "open_access":
-                return True
-            else:
-                return False
 
-        return is_can
+        return acsrole == "open_access"
 
     def __check_user_permission(user_id_list):
         """Check user permission.

--- a/modules/weko-records-ui/weko_records_ui/permissions.py
+++ b/modules/weko-records-ui/weko_records_ui/permissions.py
@@ -191,13 +191,20 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
                 return is_can
 
         try:
+            from .utils import is_future
             # can access
             if 'open_access' in acsrole:
                 if is_display_file_info:
                     # Always display the file info area in 'Detail' screen.
                     is_can = True
                 else:
-                    is_can = _is_open_date_past(acsrole)
+                    date = fjson.get('date')
+                    if date and isinstance(date, list) and date[0]:
+                        adt = date[0].get('dateValue')
+                        if adt:
+                            is_can = not is_future(adt)
+                        else:
+                            is_can = True
                     download_status["is_open_access"] = is_can
             # access with open date
             elif 'open_date' in acsrole:
@@ -206,8 +213,11 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
                     is_can = True
                 else:
                     try:
-                        is_can = _is_open_date_past(acsrole)
-                        download_status["is_open_access"] = is_can
+                        date = fjson.get('date')
+                        if date and isinstance(date, list) and date[0]:
+                            adt = date[0].get('dateValue')
+                            is_can = not is_future(adt)
+                            download_status["is_open_access"] = is_can
                     except BaseException:
                         is_can = False
 

--- a/modules/weko-records-ui/weko_records_ui/permissions.py
+++ b/modules/weko-records-ui/weko_records_ui/permissions.py
@@ -133,6 +133,8 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
             else:
                 return False
 
+        return is_can
+
     def __check_user_permission(user_id_list):
         """Check user permission.
 

--- a/modules/weko-records-ui/weko_records_ui/permissions.py
+++ b/modules/weko-records-ui/weko_records_ui/permissions.py
@@ -116,7 +116,7 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
 
         This value is decide whether display this file as open access or not.
         If the file has open date, return if the open date is past or not.
-        If the open date is past, return file's access role is open access or not.
+        If no date, return file's access role is open access or not.
 
         Args:
             acsrole (str): File permission

--- a/modules/weko-records-ui/weko_records_ui/permissions.py
+++ b/modules/weko-records-ui/weko_records_ui/permissions.py
@@ -90,7 +90,7 @@ def file_permission_factory(record, *args, **kwargs):
     return type('FileDownLoadPermissionChecker', (), {'can': can})()
 
 
-def check_file_download_permission(record, fjson, is_display_file_info=False, check_billing_file=False, download_status={}):
+def check_file_download_permission(record, fjson, is_display_file_info=False, check_billing_file=False, download_status=None):
     """Check file download."""
     def site_license_check():
         # site license permission check
@@ -157,6 +157,7 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
                     break
         return is_ok
 
+    download_status = download_status if download_status is not None else {}
     if fjson:
         is_can = True
         download_status["is_sitelicense_member"] = False
@@ -177,7 +178,7 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
         if current_user and \
                 current_user.is_authenticated and \
                 current_user.id in user_id_list:
-            if 'open_access' in acsrole or 'open_date' in acsrole:
+            if acsrole in ["open_access", "open_date"]:
                 download_status["is_open_access"] = _is_open_date_past(acsrole)
             return is_can
 
@@ -186,14 +187,14 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
             current_app.config['WEKO_PERMISSION_ROLE_COMMUNITY']
         for role in list(current_user.roles or []):
             if role.name in supers:
-                if 'open_access' in acsrole or 'open_date' in acsrole:
+                if acsrole in ["open_access", "open_date"]:
                     download_status["is_open_access"] = _is_open_date_past(acsrole)
                 return is_can
 
         try:
             from .utils import is_future
             # can access
-            if 'open_access' in acsrole:
+            if acsrole == "open_access":
                 if is_display_file_info:
                     # Always display the file info area in 'Detail' screen.
                     is_can = True
@@ -207,7 +208,7 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
                             is_can = True
                     download_status["is_open_access"] = is_can
             # access with open date
-            elif 'open_date' in acsrole:
+            elif acsrole == "open_date":
                 if is_display_file_info:
                     # Always display the file info area in 'Detail' screen.
                     is_can = True
@@ -237,7 +238,7 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
                         download_status["is_sitelicense_member"] = is_can
 
             # access with login user
-            elif 'open_login' in acsrole:
+            elif acsrole == "open_login":
                 if is_display_file_info:
                     # Always display the file info area in 'Detail' screen.
                     is_can = True
@@ -281,7 +282,7 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
                             download_status["is_sitelicense_member"] = is_can
 
             #  can not access
-            elif 'open_no' in acsrole:
+            elif acsrole == "open_no":
                 if is_display_file_info:
                     # Allow display the file info area in 'Detail' screen.
                     is_can = True
@@ -296,7 +297,7 @@ def check_file_download_permission(record, fjson, is_display_file_info=False, ch
                         is_can = True
                     else:
                         is_can = False
-            elif 'open_restricted' in acsrole:
+            elif acsrole == "open_restricted":
                 is_can = check_open_restricted_permission(record, fjson)
         except BaseException:
             abort(500)


### PR DESCRIPTION
recovery for #1119 
HIROBA_MIG-1982 2026年1月改修 課題6. アイテム詳細画面での課金ファイルのラベル表示の改修
実装修正・単体テスト