### PR TITLE
nginxコンテナのログを標準出力できるように修正

### DIFF
--- a/nginx/ecosystem.config.js
+++ b/nginx/ecosystem.config.js
@@ -5,7 +5,10 @@ module.exports = {
       port: '3000',
       exec_mode: 'cluster',
       instances: 'max',
-      script: '/usr/local/weko-frontend/.output/server/index.mjs'
+      script: '/usr/local/weko-frontend/.output/server/index.mjs',
+      output: '/root/.pm2/logs/AMS-out.log',
+      error: '/root/.pm2/logs/AMS-error.log',
+      merge_logs: true
     }
   ]
 }

--- a/nginx/startup.sh
+++ b/nginx/startup.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-pm2="pm2 start /usr/local/ecosystem.config.js"
+pm2="pm2 start /usr/local/ecosystem.config.js -s"
 eval $pm2
+
+tail -F /root/.pm2/logs/AMS-out.log >> /dev/stdout 2> >(grep -v "No such file or directory" >&2) &
+tail -F /root/.pm2/logs/AMS-error.log >> /dev/stderr 2> >(grep -v "No such file or directory" >&2) &
 
 supervisor="/usr/bin/supervisord -c /etc/supervisor/supervisord.conf"
 eval $supervisor


### PR DESCRIPTION
調査報告

① nginx/ecosystem.config.js
・ output: '/root/.pm2/logs/AMS-out.log'
　outputで標準出力ログの出力先を指定出来る。
　指定しなかった場合のデフォルトは/root/.pm2/logs/[name]-out.logになる。
　本アプリのnameがAMSのため、/root/.pm2/logs/AMS-out.logを指定。

・error: '/root/.pm2/logs/AMS-error.log'
　errorで標準エラーログの出力先を指定出来る。
　指定しなかった場合のデフォルトは/root/.pm2/logs/[name]-error.logになる。

　※ output、errorの二つはデフォルトを指定しているので記載しなくても動作に変わりはないが、
　　② nginx/startup.shとの関係が分かりやすいため、あえて記載。

・ merge_logs: true
　exec_mode: 'cluster'のため、インスタンスが分かれる。
　AMS-out.logとAMS-error.logはインスタンスごとに出力されるため、
　merge_logs: falseの場合、AMS-out-0.log、AMS-out-1.log、AMS-error-0.log、AMS-error-1.logになる。
　merge_logs: trueの場合、outputとerrorのログがそれぞれ統合され、出力されるファイルはAMS-out.logとAMS-error.logの2つになる。
　※ AMS-out.logとAMS-error.logが統合して一つのファイルになるわけではない。

② nginx/startup.sh
・pm2="pm2 start /usr/local/ecosystem.config.js -s"　
　末尾に-sをつけることで、pm2起動時の巨大なアスキーアート、ステータステーブルの出力を制限できる。

・tail -F /root/.pm2/logs/AMS-out.log >> /dev/stdout 2> >(grep -v "No such file or directory" >&2) &
　①で作成したAMS-out.logが更新されるたびに/dev/stdout(標準出力)へ流し込む。
　tailコマンドの実行タイミングによってはまだAMS-out.logが作成される前で「No such file or directory」が発生するため、
　tailコマンドでのエラーかつそのエラーが「No such file or directory」だった場合はエラー出力はさせない。
　
・tail -F /root/.pm2/logs/AMS-error.log >> /dev/stderr 2> >(grep -v "No such file or directory" >&2) &
　①で作成したAMS-error.logが更新されるたびに/dev/stderr(標準エラー出力)へ流し込む。
　上記と同じくtailコマンドでNo such file or directoryが出た場合はエラー出力はさせないが、AMS-error.logの中に「No such file or directory」が入ってる場合はエラー出力を行う。

この修正により、docker compose logs nginx を実行するとターミナルにnginxコンテナのログの内容が出力されるようになる。
また、従来通りnginxコンテナの/root/.pm2/logs/にログファイルは出力されているため、そちらで内容確認を行うことも可能。