### PR TITLE
fix unit test for check_jsonld_import_items

### DIFF
--- a/modules/weko-search-ui/tests/data/zip_crate/data/ro-crate-metadata.json
+++ b/modules/weko-search-ui/tests/data/zip_crate/data/ro-crate-metadata.json
@@ -85,13 +85,13 @@
       ],
       "hasPart": [
         {
-          "@id": "data/sample.txt"
+          "@id": "sample.txt"
         },
         {
-          "@id": "data/data.csv"
+          "@id": "data.csv"
         },
         {
-          "@id": "data/test/data.csv"
+          "@id": "test/data.csv"
         },
         {
           "@id": "https://example.com/test/sample/1"
@@ -437,7 +437,7 @@
       "value": "Example Organization"
     },
     {
-      "@id": "data/data.csv",
+      "@id": "data.csv",
       "@type": "File",
       "dcterms:accessRights": "open_login",
       "datePublished": "2025-06-06",
@@ -459,7 +459,7 @@
       "wk:textExtraction": false
     },
     {
-      "@id": "data/test/data.csv",
+      "@id": "test/data.csv",
       "@type": "File",
       "dcterms:accessRights": "open_login",
       "datePublished": "2025-06-06",
@@ -481,7 +481,7 @@
       "wk:textExtraction": true
     },
     {
-      "@id": "data/sample.txt",
+      "@id": "sample.txt",
       "@type": "File",
       "dcterms:accessRights": "open_access",
       "datePublished": "2025-06-06",


### PR DESCRIPTION
#1088 の修正を入れる際に単体テストを実施したところ通らなかったため、ファイルはdataフォルダからの相対パスで記述するという仕様に合わせて、テストデータに  b291cd9efa0aac05139c55bfe73fb62ed651475b と同様の修正