### PR TITLE
fix: shib_handle

### DIFF
--- a/modules/weko-accounts/weko_accounts/api.py
+++ b/modules/weko-accounts/weko_accounts/api.py
@@ -35,6 +35,8 @@ class ShibUser(object):
         :param shib_attr: passed attribute for shibboleth user
         """
         self.shib_attr = shib_attr
+        if self.shib_attr['shib_handle']:
+            self.shib_attr['shib_handle']=self.shib_attr['shib_handle'][:255]
         self.user = None
         """The :class:`invenio_accounts.models.User` instance."""
         self.shib_user = None
@@ -150,7 +152,7 @@ class ShibUser(object):
                 if self.shib_attr['shib_organization']:
                     shib_user.shib_organization = self.shib_attr['shib_organization']
                 if self.shib_attr['shib_handle']:
-                    shib_user.shib_handle = self.shib_attr['shib_handle'][:255]
+                    shib_user.shib_handle = self.shib_attr['shib_handle']
             db.session.commit()
         except SQLAlchemyError as ex:
             current_app.logger.error("SQLAlchemyError: {}".format(ex))


### PR DESCRIPTION
HIROBA_MIG-1874 シボレスログイン時にメールアドレスの代わりにUMSの「表示名」を表示する
ITW2025-33-803
頭の255字を保存する処理