### PR TITLE
fix: shib_handle

### DIFF
--- a/modules/weko-accounts/weko_accounts/api.py
+++ b/modules/weko-accounts/weko_accounts/api.py
@@ -35,7 +35,7 @@ class ShibUser(object):
         :param shib_attr: passed attribute for shibboleth user
         """
         self.shib_attr = shib_attr
-        if self.shib_attr['shib_handle']:
+        if self.shib_attr.get('shib_handle'):
             self.shib_attr['shib_handle']=self.shib_attr['shib_handle'][:255]
         self.user = None
         """The :class:`invenio_accounts.models.User` instance."""


### PR DESCRIPTION
HIROBA_MIG-1874 シボレスログイン時にメールアドレスの代わりにUMSの「表示名」を表示する
fix init get key