### PR TITLE
 W2026-31 weko-workflow 単体テスト修正

### DIFF
--- a/modules/weko-items-ui/weko_items_ui/assets/bootstrap3/js/weko_items_ui/app.js
+++ b/modules/weko-items-ui/weko_items_ui/assets/bootstrap3/js/weko_items_ui/app.js
@@ -1291,7 +1291,7 @@ function toObject(arr) {
                                 var provide_form = get_subitem(filemeta_form.items, 'provide');
                                 var role_form = get_subitem(provide_form.items, 'role');
                                 role_form['titleMap'] = [];
-                                var roles = dataInit['init_roles'];
+                                var roles = dataInit['logged_roles'];
                                 for (let key in roles) {
                                     role_schema['enum'].push(roles[key]['id'].toString());
                                     role_form['titleMap'].push({

--- a/modules/weko-theme/weko_theme/config.py
+++ b/modules/weko-theme/weko_theme/config.py
@@ -575,3 +575,6 @@ ENABLE_COOKIE_CONSENT = False
 
 WEKO_THEME_FETCH_SEARCH_FLG = True
 """ Enable DOM differential update functionality when searching. """
+
+WEKO_THEME_AUTO_CORRECT_LOCATION_HEADER = True
+""" Auto correct location header to be absolute URL when using reverse proxy. """

--- a/modules/weko-theme/weko_theme/ext.py
+++ b/modules/weko-theme/weko_theme/ext.py
@@ -49,6 +49,11 @@ class WekoTheme(object):
         app.add_template_filter(
             get_search_detail_keyword,
             name='detail_conditions')
+        # Update auto correct location header config
+        # Werkzeug 2.3.0+ will auto correct location header to be absolute URL when using reverse proxy.
+        app.response_class.autocorrect_location_header = app.config.get(
+            "WEKO_THEME_AUTO_CORRECT_LOCATION_HEADER", False
+        )
 
     def init_config(self, app):
         """Initialize configuration.

--- a/modules/weko-workflow/tests/conftest.py
+++ b/modules/weko-workflow/tests/conftest.py
@@ -36,6 +36,7 @@ from invenio_files_rest import InvenioFilesREST
 from invenio_records import InvenioRecords
 from invenio_oauth2server import InvenioOAuth2Server
 from invenio_records_ui import InvenioRecordsUI
+from invenio_records_ui.views import create_blueprint_from_app as invenio_records_ui_create_blueprint
 from invenio_rest import InvenioREST
 from invenio_pidrelations import InvenioPIDRelations
 from invenio_pidstore import InvenioPIDStore
@@ -49,6 +50,7 @@ from invenio_oauth2server.models import Client, Token
 from invenio_oauth2server.views import settings_blueprint as oauth2server_settings_blueprint
 from invenio_records_files.api import RecordsBuckets
 from io import BytesIO
+from kombu import Exchange, Queue
 from mock import patch
 from opensearchpy import OpenSearch
 from unittest.mock import patch
@@ -70,6 +72,7 @@ from weko_schema_ui.config import (
     WEKO_SCHEMA_JPCOAR_V1_SCHEMA_NAME,WEKO_SCHEMA_DDI_SCHEMA_NAME)
 from weko_search_ui import WekoSearchUI
 from weko_search_ui.config import WEKO_SYS_USER
+from weko_theme import WekoTheme
 from weko_theme.config import THEME_INSTITUTION_NAME
 from weko_records.models import (
     ItemTypeName, ItemType,FeedbackMailList,ItemTypeMapping,ItemTypeProperty)
@@ -106,6 +109,7 @@ from sqlalchemy_utils.functions import create_database, database_exists, \
     drop_database
 from .helpers import (
     json_data, create_record, fill_oauth2_headers, create_activity, create_flow)
+from weko_deposit.config import PIDRELATIONS_RELATION_TYPES
 
 sys.path.append(os.path.dirname(__file__))
 # @event.listens_for(Engine, "connect")
@@ -501,6 +505,12 @@ def base_app(instance_path, search_class, cache_config):
         INDEXER_FILE_DOC_TYPE="content",
         INDEXER_DEFAULT_DOC_TYPE='testrecord',
         INDEXER_DEFAULT_INDEX=search_class.Meta.index,
+        INDEXER_MQ_QUEUE = Queue(
+            "indexer",
+            exchange=Exchange("indexer", type="direct"),
+            routing_key="indexer",
+            queue_arguments={"x-queue-type":"quorum"}
+        ),
         WEKO_INDEX_TREE_DEFAULT_DISPLAY_NUMBER=WEKO_INDEX_TREE_DEFAULT_DISPLAY_NUMBER,
         WEKO_SCHEMA_JPCOAR_V1_SCHEMA_NAME=WEKO_SCHEMA_JPCOAR_V1_SCHEMA_NAME,
         WEKO_SCHEMA_JPCOAR_V2_SCHEMA_NAME='jpcoar_mapping',
@@ -586,9 +596,12 @@ def base_app(instance_path, search_class, cache_config):
         WEKO_WORKFLOW_USAGE_REPORT_WORKFLOW_NAME = '利用報告/Data Usage Report',
         WEKO_WORKFLOW_TODO_TAB = 'todo',
         WEKO_HANDLE_CREDS_JSON_PATH='/code/modules/resources/handle_creds.json',
+        WEKO_ADMIN_PERMISSION_ROLE_SYSTEM="System Administrator",
+        WEKO_ADMIN_PERMISSION_ROLE_REPO="Repository Administrator",
         WEKO_ADMIN_RESTRICTED_ACCESS_DISPLAY_FLAG = False,
         WEKO_ADMIN_DISPLAY_RESTRICTED_SETTINGS = True,
         WEKO_RECORDS_UI_RESTRICTED_API= False,
+        PIDRELATIONS_RELATION_TYPES=PIDRELATIONS_RELATION_TYPES,
     )
 
     app_.testing = True
@@ -630,6 +643,7 @@ def base_app(instance_path, search_class, cache_config):
         WekoLoggingUserActivity(app_)
         WekoNotifications(app_)
         # WekoRecordsUI(app_)
+        WekoTheme(app_)
         app_.register_blueprint(invenio_communities_blueprint)
         # app_.register_blueprint(invenio_admin_blueprint)
         # app_.register_blueprint(invenio_accounts_blueprint)
@@ -638,6 +652,11 @@ def base_app(instance_path, search_class, cache_config):
         # app_.register_blueprint(weko_workflow_blueprint)
         WekoWorkflowREST(app_)
         app_.register_blueprint(oauth2server_settings_blueprint)
+        app_.register_blueprint(
+            invenio_records_ui_create_blueprint(app_)
+        )
+        # Enable Jinja2 extensions for testing purposes
+        app_.jinja_env.add_extension("jinja2.ext.do")
 
         return app_
 
@@ -667,17 +686,6 @@ def db(app):
     db_.drop_all()
     drop_database(str(db_.engine.url))
 
-@pytest.yield_fixture()
-def logging_client(app):
-    """make a test client.
-    Args:
-        app (Flask): flask app.
-    Yields:
-        FlaskClient: test client
-    """
-    test = WekoLoggingUserActivity()
-    test.init_app(app)
-    yield app
 
 @pytest.yield_fixture()
 def client(app):
@@ -722,7 +730,7 @@ def users(app, db):
     if not user:
         user = create_test_user(email='user@test.org')
 
-    contributor = User.query.filter_by(email='user@test.org').one_or_none()
+    contributor = User.query.filter_by(email='contributor@test.org').one_or_none()
     if not contributor:
         contributor = create_test_user(email='contributor@test.org')
 
@@ -858,10 +866,16 @@ def users(app, db):
         db.session.add(index)
         db.session.commit()
 
+    # Create community role
+    comrole = Role.query.filter_by(name="community_role").one_or_none()
+    if not comrole:
+        comrole = ds.create_role(name="community_role")
+    # Add community role to comadmin user to allow access to community management
+    ds.add_role_to_user(comadmin, comrole)
 
     comm = Community.query.filter_by(id="comm01").one_or_none()
     if not comm:
-        comm = Community.create(community_id="comm01", role_id=sysadmin_role.id,
+        comm = Community.create(community_id="comm01", role_id=comrole.id,
                             id_user=sysadmin.id, title="test community",
                             description=("this is test community"),
                             root_node_id=index.id)
@@ -1113,42 +1127,43 @@ def item_type_usage_report(db):
         )
         db.session.add(item_type_name)
 
-        item_type_schema = dict()
-        with open("tests/data/item_type/itemtype_schema_31003.json", "r") as f:
-            item_type_schema = json.load(f)
+    item_type_schema = dict()
+    with open("tests/data/item_type/itemtype_schema_31003.json", "r") as f:
+        item_type_schema = json.load(f)
 
-        item_type_form = dict()
-        with open("tests/data/item_type/itemtype_form_31003.json", "r") as f:
-            item_type_form = json.load(f)
+    item_type_form = dict()
+    with open("tests/data/item_type/itemtype_form_31003.json", "r") as f:
+        item_type_form = json.load(f)
 
-        item_type_render = dict()
-        with open("tests/data/item_type/itemtype_render_31003.json", "r") as f:
-            item_type_render = json.load(f)
+    item_type_render = dict()
+    with open("tests/data/item_type/itemtype_render_31003.json", "r") as f:
+        item_type_render = json.load(f)
 
-        item_type_mapping = dict()
-        with open("tests/data/item_type/itemtype_mapping_31003.json", "r") as f:
-            item_type_mapping = json.load(f)
+    item_type_mapping = dict()
+    with open("tests/data/item_type/itemtype_mapping_31003.json", "r") as f:
+        item_type_mapping = json.load(f)
 
-        item_type = ItemType(
-            id=31003,
-            name_id=31003,
-            harvesting_type=False,
-            schema=item_type_schema,
-            form=item_type_form,
-            render=item_type_render,
-            tag=1,
-            version_id=1,
-            is_deleted=False,
-        )
-
+    item_type = ItemType(
+        id=31003,
+        name_id=31003,
+        harvesting_type=False,
+        schema=item_type_schema,
+        form=item_type_form,
+        render=item_type_render,
+        tag=1,
+        version_id=1,
+        is_deleted=False,
+    )
+    with db.session.begin_nested():
         db.session.add(item_type)
 
-        item_type_mapping = ItemTypeMapping(
-            id=31003,
-            item_type_id=31003,
-            mapping=item_type_mapping
-        )
+    item_type_mapping = ItemTypeMapping(
+        id=31003,
+        item_type_id=item_type.id,
+        mapping=item_type_mapping
+    )
 
+    with db.session.begin_nested():
         db.session.add(item_type_mapping)
     return item_type
 
@@ -1239,12 +1254,15 @@ def db_itemtype(app, db):
         version_id=1,
         is_deleted=False,
     )
-
-    item_type_mapping = ItemTypeMapping(id=1,item_type_id=1, mapping=item_type_mapping)
-
     with db.session.begin_nested():
         db.session.add(item_type_name)
         db.session.add(item_type)
+
+    item_type_mapping = ItemTypeMapping(
+        id=1, item_type_id=item_type.id, mapping=item_type_mapping
+    )
+
+    with db.session.begin_nested():
         db.session.add(item_type_mapping)
 
     return {"item_type_name": item_type_name, "item_type": item_type, "item_type_mapping":item_type_mapping}
@@ -1282,12 +1300,15 @@ def db_itemtype2(app, db):
         version_id=1,
         is_deleted=False,
     )
-
-    item_type_mapping = ItemTypeMapping(id=15,item_type_id=15, mapping=item_type_mapping)
-
     with db.session.begin_nested():
         db.session.add(item_type_name)
         db.session.add(item_type)
+
+    item_type_mapping = ItemTypeMapping(
+        id=15, item_type_id=item_type.id, mapping=item_type_mapping
+    )
+
+    with db.session.begin_nested():
         db.session.add(item_type_mapping)
 
     return {"item_type_name": item_type_name, "item_type": item_type, "item_type_mapping":item_type_mapping}
@@ -1357,12 +1378,14 @@ def item_type(db):
         version_id=1,
         is_deleted=False,
     )
-
-    item_type_mapping_31001 = ItemTypeMapping(id=31001, item_type_id=31001, mapping=item_type_mapping_31001)
-
     with db.session.begin_nested():
         db.session.add(item_type_name_31001)
         db.session.add(item_type_31001)
+
+    item_type_mapping_31001 = ItemTypeMapping(
+        id=31001, item_type_id=item_type_31001.id, mapping=item_type_mapping_31001
+    )
+    with db.session.begin_nested():
         db.session.add(item_type_mapping_31001)
 
     item_types.append({"id": 31001, "obj": item_type_31001})
@@ -1529,81 +1552,148 @@ def db_register_full_action(app, db, db_records, users, action_data, item_type):
         db.session.add(app_flow_action3)
     db.session.commit()
 
-    action_role_1 = FlowActionRole.query.filter_by(flow_action_id=flow_action1.id, action_role=1, action_user=1).one_or_none()
+    # Get system administrator role and repository administrator role
+    sysadmin_role = Role.query.filter_by(name='System Administrator').one()
+    repoadmin_role = Role.query.filter_by(name='Repository Administrator').one()
+
+    action_role_1 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action1.id,
+        action_role=sysadmin_role.id,
+        action_user=1
+    ).one_or_none()
     if not action_role_1:
-        action_role_1 = FlowActionRole(flow_action_id=flow_action1.id,
-                                   action_role=1,
-                                   action_user=1)
+        action_role_1 = FlowActionRole(
+            flow_action_id=flow_action1.id,
+            action_role=sysadmin_role.id,
+            action_user=1
+        )
 
-    action_role_2_1 = FlowActionRole.query.filter_by(flow_action_id=flow_action2.id, action_role=1, action_user=2).one_or_none()
+    action_role_2_1 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action2.id,
+        action_role=sysadmin_role.id,
+        action_user=2
+    ).one_or_none()
     if not action_role_2_1:
-        action_role_2_1 = FlowActionRole(flow_action_id=flow_action2.id,
-                                   action_role=1,
-                                   action_user=2)
+        action_role_2_1 = FlowActionRole(
+            flow_action_id=flow_action2.id,
+            action_role=sysadmin_role.id,
+            action_user=2
+        )
 
-    action_role_2_2 = FlowActionRole.query.filter_by(flow_action_id=flow_action2.id, action_role=2, action_user=1).one_or_none()
+    action_role_2_2 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action2.id,
+        action_role=repoadmin_role.id,
+        action_user=1
+    ).one_or_none()
     if not action_role_2_2:
-        action_role_2_2 = FlowActionRole(flow_action_id=flow_action2.id,
-                                   action_role=2,
-                                   action_user=1)
+        action_role_2_2 = FlowActionRole(
+            flow_action_id=flow_action2.id,
+            action_role=repoadmin_role.id,
+            action_user=1
+        )
 
-    action_role_2_3 = FlowActionRole.query.filter_by(flow_action_id=flow_action2.id, action_role=2, action_user=2).one_or_none()
+    action_role_2_3 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action2.id,
+        action_role=repoadmin_role.id,
+        action_user=2
+    ).one_or_none()
     if not action_role_2_3:
-        action_role_2_3 = FlowActionRole(flow_action_id=flow_action2.id,
-                                   action_role=2,
-                                   action_user=2)
+        action_role_2_3 = FlowActionRole(
+            flow_action_id=flow_action2.id,
+            action_role=repoadmin_role.id,
+            action_user=2
+        )
 
-    action_role_2_4 = FlowActionRole.query.filter_by(flow_action_id=flow_action2.id, action_role=2, action_user=3).one_or_none()
+    action_role_2_4 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action2.id,
+        action_role=repoadmin_role.id,
+        action_user=3
+    ).one_or_none()
     if not action_role_2_4:
-        action_role_2_4 = FlowActionRole(flow_action_id=flow_action2.id,
-                                   action_role=2,
-                                   action_user=3)
+        action_role_2_4 = FlowActionRole(
+            flow_action_id=flow_action2.id,
+            action_role=repoadmin_role.id,
+            action_user=3
+        )
 
-    action_role_3 = FlowActionRole.query.filter_by(flow_action_id=flow_action3.id, action_role=1, action_user=3).one_or_none()
+    action_role_3 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action3.id,
+        action_role=sysadmin_role.id,
+        action_user=3
+    ).one_or_none()
     if not action_role_3:
-        action_role_3 = FlowActionRole(flow_action_id=flow_action3.id,
-                                   action_role=1,
-                                   action_user=3)
+        action_role_3 = FlowActionRole(
+            flow_action_id=flow_action3.id,
+            action_role=sysadmin_role.id,
+            action_user=3
+        )
 
-    action_role_4_1 = FlowActionRole.query.filter_by(flow_action_id=flow_action4.id, action_role=1, action_user=1, action_role_exclude=True, action_user_exclude=True).one_or_none()
+    action_role_4_1 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action4.id,
+        action_role=sysadmin_role.id,
+        action_user=1,
+        action_role_exclude=True,
+        action_user_exclude=True
+    ).one_or_none()
     if not action_role_4_1:
-        action_role_4_1 = FlowActionRole(flow_action_id=flow_action4.id,
-                                   action_role=1,
-                                   action_user=1,
-                                   action_role_exclude=True,
-                                   action_user_exclude=True
-                                   )
+        action_role_4_1 = FlowActionRole(
+            flow_action_id=flow_action4.id,
+            action_role=sysadmin_role.id,
+            action_user=1,
+            action_role_exclude=True,
+            action_user_exclude=True
+        )
 
-    action_role_4_2 = FlowActionRole.query.filter_by(flow_action_id=flow_action4.id, action_role=1, action_user=2, action_role_exclude=True, action_user_exclude=True).one_or_none()
+    action_role_4_2 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action4.id,
+        action_role=sysadmin_role.id,
+        action_user=2,
+        action_role_exclude=True,
+        action_user_exclude=True
+    ).one_or_none()
     if not action_role_4_2:
         action_role_4_2 = FlowActionRole(flow_action_id=flow_action4.id,
-                                   action_role=1,
+                                   action_role=sysadmin_role.id,
                                    action_user=2,
                                    action_role_exclude=True,
                                    action_user_exclude=True
                                    )
 
-    action_role_4_3 = FlowActionRole.query.filter_by(flow_action_id=flow_action4.id, action_role=1, action_user=3, action_role_exclude=False, action_user_exclude=False).one_or_none()
+    action_role_4_3 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action4.id,
+        action_role=sysadmin_role.id,
+        action_user=3,
+        action_role_exclude=False,
+        action_user_exclude=False
+    ).one_or_none()
     if not action_role_4_3:
-        action_role_4_3 = FlowActionRole(flow_action_id=flow_action4.id,
-                                   action_role=1,
-                                   action_user=3,
-                                   action_role_exclude=False,
-                                   action_user_exclude=False
-                                   )
+        action_role_4_3 = FlowActionRole(
+            flow_action_id=flow_action4.id,
+            action_role=sysadmin_role.id,
+            action_user=3,
+            action_role_exclude=False,
+            action_user_exclude=False
+        )
 
-    action_role_4_4 = FlowActionRole.query.filter_by(flow_action_id=flow_action4.id, action_role=2, action_user=1).one_or_none()
+    action_role_4_4 = FlowActionRole.query.filter_by(
+        flow_action_id=flow_action4.id,
+        action_role=repoadmin_role.id,
+        action_user=1
+    ).one_or_none()
     if not action_role_4_4:
-        action_role_4_4 = FlowActionRole(flow_action_id=flow_action4.id,
-                                   action_role=2,
-                                   action_user=1
-                                   )
-    action_role_5 = FlowActionRole(flow_action_id=flow_action4.id,
-                                   action_role=2,
-                                   action_user=1,
-                                   specify_property="test",
-                                   action_item_registrant=True
-                                   )
+        action_role_4_4 = FlowActionRole(
+            flow_action_id=flow_action4.id,
+            action_role=repoadmin_role.id,
+            action_user=1
+        )
+
+    action_role_5 = FlowActionRole(
+        flow_action_id=flow_action4.id,
+        action_role=repoadmin_role.id,
+        action_user=1,
+        specify_property="test",
+        action_item_registrant=True
+    )
     with db.session.begin_nested():
         db.session.add(action_role_1)
         db.session.add(action_role_2_1)
@@ -1788,15 +1878,22 @@ def db_register_full_action(app, db, db_records, users, action_data, item_type):
 
     activity_item7 = Activity.query.filter_by(activity_id='8').one_or_none()
     if not activity_item7:
-        activity_item7 = Activity(activity_id='8', item_id=db_records[0][2].id,workflow_id=1, flow_id=flow_define.id,
-                    action_id=3, activity_login_user=users[3]["id"],
-                    activity_update_user=1,
-                    activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
-                    activity_community_id=3,
-                    activity_confirm_term_of_use=True,
-                    title='test item8', shared_user_ids=[], extra_info={},
-                    action_order=1,
-                    )
+        activity_item7 = Activity(
+            activity_id='8',
+            item_id=db_records[0][2].id,
+            workflow_id=1,
+            flow_id=flow_define.id,
+            action_id=3,
+            activity_login_user=users[3]["id"],
+            activity_update_user=1,
+            activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
+            activity_community_id=3,
+            activity_confirm_term_of_use=True,
+            title='test item8',
+            shared_user_ids=[],
+            extra_info={},
+            action_order=1,
+        )
 
     activity_item8 = Activity.query.filter_by(activity_id='9').one_or_none()
     if not activity_item8:
@@ -2157,7 +2254,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test', shared_user_id=-1, extra_info={},
+                    title='test', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity2 = Activity(activity_id='A-00000001-10001',workflow_id=1, flow_id=flow_define.id,
@@ -2167,7 +2264,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test', shared_user_id=-1, extra_info={},
+                    title='test', shared_user_ids=[], extra_info={},
                     action_order=6)
 
     activity3 = Activity(activity_id='A-00000001-10002',workflow_id=1, flow_id=flow_define.id,
@@ -2177,7 +2274,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test', shared_user_id=-1, extra_info={},
+                    title='test', shared_user_ids=[], extra_info={},
                     action_order=6)
     activity_item1 = Activity(activity_id='2',item_id=db_records[2][2].id,workflow_id=1, flow_id=flow_define.id,
                     action_id=1, activity_login_user=users[3]["id"],
@@ -2185,7 +2282,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item1', shared_user_id=-1, extra_info={},
+                    title='test item1', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_item2 = Activity(activity_id='3', workflow_id=1, flow_id=flow_define.id,
@@ -2194,7 +2291,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item2', shared_user_id=-1, extra_info={},
+                    title='test item2', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_item3 = Activity(activity_id='4', workflow_id=1, flow_id=flow_define.id,
@@ -2203,7 +2300,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item3', shared_user_id=-1, extra_info={},
+                    title='test item3', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_item4 = Activity(activity_id='5', workflow_id=1, flow_id=flow_define.id,
@@ -2212,7 +2309,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item4', shared_user_id=-1, extra_info={},
+                    title='test item4', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_item5 = Activity(activity_id='6', workflow_id=1, flow_id=flow_define.id,
@@ -2221,7 +2318,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item5', shared_user_id=-1, extra_info={},
+                    title='test item5', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_item6 = Activity(activity_id='7', workflow_id=1, flow_id=flow_define.id,
@@ -2230,7 +2327,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item5', shared_user_id=-1, extra_info={},
+                    title='test item5', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_item7 = Activity(activity_id='8', item_id=db_records[0][2].id,workflow_id=1, flow_id=flow_define.id,
@@ -2239,7 +2336,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item8', shared_user_id=-1, extra_info={},
+                    title='test item8', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_item8 = Activity(activity_id='9', item_id=db_records[1][2].id,workflow_id=1, flow_id=flow_define.id,
@@ -2248,7 +2345,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item8', shared_user_id=-1, extra_info={},
+                    title='test item8', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     activity_guest = Activity(activity_id='guest', item_id=db_records[1][2].id,workflow_id=1, flow_id=flow_define.id,
@@ -2257,7 +2354,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item8', shared_user_id=-1,
+                    title='test item8', shared_user_ids=[],
                     action_order=1,
                     extra_info={"guest_mail":"guest@test.org","related_title":"related_guest_activity","usage_record_id":str(db_records[1][2].id),"usage_activity_id":str(uuid.uuid4())}
                     )
@@ -2338,7 +2435,7 @@ def db_register(app, db, db_records, users, action_data, item_type):
                     activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
                     activity_community_id=3,
                     activity_confirm_term_of_use=True,
-                    title='test item5', shared_user_id=-1, extra_info={},
+                    title='test item5', shared_user_ids=[], extra_info={},
                     action_order=1,
                     )
     with db.session.begin_nested():
@@ -3593,7 +3690,7 @@ def db_register_usage_application_workflows(app, db, action_data, item_type ):
 
 
 @pytest.fixture()
-def db_register_usage_application(app, db, db_records, users, action_data, item_type, db_register_usage_application_workflows ):
+def db_register_usage_application(app, db, db_records, users, action_data, item_type, db_register_usage_application_workflows):
     workflows = db_register_usage_application_workflows
 
     # 利用登録(now -> item_registration, next ->end)
@@ -4288,429 +4385,6 @@ def workflow_approval(app, db, item_type, action_data, users):
     }
 
 
-def db_register_usage_application(app, db, db_records, users, action_data, item_type ):
-    workflows = {}
-
-
-    flow_id1 = uuid.uuid4()
-    # flow_id2 = uuid.uuid4()
-    flow_id3 = uuid.uuid4()
-    flow_id4 = uuid.uuid4()
-
-    #workflow_flow_define
-    flow_define1 = FlowDefine(
-        flow_id=flow_id1, flow_name="利用登録", flow_user=1, flow_status="A"
-    )
-    flow_define3 = FlowDefine(
-        flow_id=flow_id3, flow_name="利用申請", flow_user=1, flow_status="A"
-    )
-    flow_define4 = FlowDefine(
-        flow_id=flow_id4, flow_name="2段階利用申請", flow_user=1, flow_status="A"
-    )
-
-    # workflow_flow_action
-    flow_action1_1 = FlowAction(
-        status="N",
-        flow_id=flow_id1,
-        action_id=1,
-        action_version="1.0.0",
-        action_order=1,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action1_2 = FlowAction(
-        status="N",
-        flow_id=flow_id1,
-        action_id=2,
-        action_version="1.0.0",
-        action_order=3,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action1_3 = FlowAction(
-        status="N",
-        flow_id=flow_id1,
-        action_id=3,
-        action_version="1.0.1",
-        action_order=2,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": True, "request_approval": False},
-    )
-
-    flow_action3_1 = FlowAction(
-        status="N",
-        flow_id=flow_id3,
-        action_id=1,
-        action_version="1.0.0",
-        action_order=1,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action3_2 = FlowAction(
-        status="N",
-        flow_id=flow_id3,
-        action_id=2,
-        action_version="1.0.0",
-        action_order=4,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action3_3 = FlowAction(
-        status="N",
-        flow_id=flow_id3,
-        action_id=3,
-        action_version="1.0.1",
-        action_order=2,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action3_4 = FlowAction(
-        status="N",
-        flow_id=flow_id3,
-        action_id=4,
-        action_version="2.0.0",
-        action_order=3,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": True, "inform_approval": True, "request_approval": True},
-    )
-    flow_action4_1 = FlowAction(
-        status="N",
-        flow_id=flow_id4,
-        action_id=1,
-        action_version="1.0.0",
-        action_order=1,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action4_2 = FlowAction(
-        status="N",
-        flow_id=flow_id4,
-        action_id=2,
-        action_version="1.0.0",
-        action_order=5,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action4_3 = FlowAction(
-        status="N",
-        flow_id=flow_id4,
-        action_id=3,
-        action_version="1.0.1",
-        action_order=2,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": False, "inform_approval": False, "request_approval": False},
-    )
-    flow_action4_4 = FlowAction(
-        status="N",
-        flow_id=flow_id4,
-        action_id=4,
-        action_version="2.0.0",
-        action_order=3,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": True, "inform_approval": True, "request_approval": True},
-    )
-    flow_action4_5 = FlowAction(
-        status="N",
-        flow_id=flow_id4,
-        action_id=4,
-        action_version="2.0.0",
-        action_order=4,
-        action_condition="",
-        action_status="A",
-        action_date=datetime.strptime("2018/07/28 0:00:00", "%Y/%m/%d %H:%M:%S"),
-        send_mail_setting={"inform_reject": True, "inform_approval": True, "request_approval": True},
-    )
-
-
-    with db.session.begin_nested():
-        db.session.add_all([flow_define1,flow_define3,flow_define4])
-    db.session.commit()
-    #workflow_workflow
-    workflow_workflow1 = WorkFlow(
-        flows_id=flow_id1,
-        flows_name="利用登録",
-        itemtype_id=1,
-        index_tree_id=None,
-        flow_id=flow_define1.id,
-        flow_define=flow_define1,
-        is_deleted=False,
-        open_restricted=True,
-        # location_id=location.id,
-        # location=location,
-        is_gakuninrdm=False,
-    )
-
-    workflow_workflow3 = WorkFlow(
-        flows_id=flow_id3,
-        flows_name="利用申請",
-        itemtype_id=1,
-        index_tree_id=None,
-        flow_id=flow_define3.id,
-        flow_define=flow_define3,
-        is_deleted=False,
-        open_restricted=True,
-        # location_id=location.id,
-        # location=location,
-        is_gakuninrdm=False,
-    )
-    workflow_workflow4 = WorkFlow(
-        flows_id=flow_id4,
-        flows_name="2段階利用申請",
-        itemtype_id=1,
-        index_tree_id=None,
-        flow_id=flow_define4.id,
-        flow_define=flow_define4,
-        is_deleted=False,
-        open_restricted=True,
-        # location_id=location.id,
-        # location=location,
-        is_gakuninrdm=False,
-    )
-
-    with db.session.begin_nested():
-        db.session.add_all([flow_action1_1,flow_action1_2,flow_action1_3])
-
-        db.session.add_all([flow_action3_1,flow_action3_2,flow_action3_3,flow_action3_4])
-        db.session.add_all([flow_action4_1,flow_action4_2,flow_action4_3,flow_action4_4,flow_action4_5])
-        db.session.add_all([workflow_workflow1, workflow_workflow3, workflow_workflow4])
-    db.session.commit()
-    workflows.update({
-		"flow_define1"       : flow_define1
-		# ,"flow_define2"       : flow_define2
-		,"flow_define3"       : flow_define3
-		,"flow_define4"       : flow_define4
-		,"flow_action1_1"     : flow_action1_1
-		,"flow_action1_2"     : flow_action1_2
-		,"flow_action1_3"     : flow_action1_3
-		# ,"flow_action2_1"     : flow_action2_1
-		# ,"flow_action2_2"     : flow_action2_2
-		,"flow_action3_1"     : flow_action3_1
-		,"flow_action3_2"     : flow_action3_2
-		,"flow_action3_3"     : flow_action3_3
-		,"flow_action3_4"     : flow_action3_4
-		,"flow_action4_1"     : flow_action4_1
-		,"flow_action4_2"     : flow_action4_2
-		,"flow_action4_3"     : flow_action4_3
-		,"flow_action4_4"     : flow_action4_4
-		,"flow_action4_5"     : flow_action4_5
-		,"workflow_workflow1" : workflow_workflow1
-		# ,"workflow_workflow2" : workflow_workflow2
-		,"workflow_workflow3" : workflow_workflow3
-		,"workflow_workflow4" : workflow_workflow4
-    })
-
-    # 利用登録(now -> item_registration, next ->end)
-    activity1 = Activity(activity_id='A-00000001-20001'
-                        ,workflow_id=workflow_workflow1.id
-                        , flow_id=flow_define1.id,
-                    action_id=3,
-                    item_id=db_records[2][2].id,
-                    activity_login_user=1,
-                    action_status = 'M',
-                    activity_update_user=1,
-                    activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f'),
-                    activity_community_id=None,
-                    activity_confirm_term_of_use=True,
-                    title='test'
-                    , shared_user_id=-1
-                    , extra_info={},
-                    action_order=2)
-    activity1_pre_action = ActivityAction(
-        activity_id='A-00000001-20001'
-        ,action_id=3
-        ,action_status = 'M'
-        ,action_order=2
-    )
-    activity1_next_action = ActivityAction(
-        activity_id='A-00000001-20001'
-        ,action_id=2
-        ,action_status = 'M'
-        ,action_order=3
-    )
-    # 利用申請(next ->end)
-    activity2 = Activity(activity_id='A-00000001-20002'
-                        ,workflow_id=workflow_workflow3.id
-                        ,flow_id=flow_define3.id
-                        ,action_id=4
-                        ,item_id=db_records[2][2].id
-                    , activity_login_user=1
-                    , action_status = 'M'
-                    , activity_update_user=1
-                    , activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f')
-                    , activity_community_id=3
-                    , activity_confirm_term_of_use=True
-                    , title='test'
-                    , shared_user_id=-1
-                    , extra_info={}
-                    , action_order=3)
-    activity2_pre_action = ActivityAction(
-        activity_id='A-00000001-20002'
-        ,action_id=4
-        ,action_status = 'M'
-        ,action_order=3
-    )
-    activity2_next_action = ActivityAction(
-        activity_id='A-00000001-20002'
-        ,action_id=2
-        ,action_status = 'M'
-        ,action_order=4
-        ,action_handler=-1
-    )
-    file_permission = FilePermission(
-        user_id = 1
-        ,record_id= 1
-        ,file_name= "aaa.txt"
-        ,usage_application_activity_id='A-00000001-20002'
-        ,usage_report_activity_id=None
-        ,status = -1
-    )
-    # ２段階利用申請(next -> approval2)
-    activity3 = Activity(activity_id='A-00000001-20003'
-                        ,workflow_id=workflow_workflow4.id
-                        ,flow_id=flow_define4.id
-                        ,action_id=4
-                        ,item_id=db_records[2][2].id
-                        ,activity_login_user=1
-                        ,action_status = 'M'
-                        ,activity_update_user=1
-                        ,activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f')
-                        ,activity_community_id=3
-                        ,activity_confirm_term_of_use=True
-                        ,title='test'
-                        ,shared_user_id=-1
-                        ,extra_info={"file_name": "aaa.txt", "record_id": "1", "user_mail": "aaa@test.org", "related_title": "test", "is_restricted_access": True}
-                        ,action_order=3)
-    activity3_pre_action = ActivityAction(
-        activity_id='A-00000001-20003'
-        ,action_id=4
-        ,action_status = 'M'
-        ,action_order=3
-    )
-    activity3_next_action = ActivityAction(
-        activity_id='A-00000001-20003'
-        ,action_id=4
-        ,action_status = 'M'
-        ,action_order=4
-    )
-    # ２段階利用申請(next ->end)
-    activity4 = Activity(activity_id='A-00000001-20004'
-                        ,workflow_id=workflow_workflow4.id
-                        ,flow_id=flow_define4.id
-                        ,action_id=4
-                        ,item_id=db_records[2][2].id
-                        ,activity_login_user=1
-                        ,action_status = 'M'
-                        ,activity_update_user=1
-                        ,activity_start=datetime.strptime('2022/04/14 3:01:53.931', '%Y/%m/%d %H:%M:%S.%f')
-                        ,activity_community_id=3
-                        ,activity_confirm_term_of_use=True
-                        ,title='test'
-                        ,shared_user_id=-1
-                        ,extra_info={"file_name": "aaa.txt", "record_id": "1", "user_mail": "aaa@test.org", "related_title": "test", "is_restricted_access": True}
-                        ,action_order=4)
-    activity4_pre_action = ActivityAction(
-        activity_id='A-00000001-20004'
-        ,action_id=4
-        ,action_status = 'M'
-        ,action_order=4
-    )
-    activity4_next_action = ActivityAction(
-        activity_id='A-00000001-20004'
-        ,action_id=2
-        ,action_status = 'M'
-        ,action_order=5
-    )
-    guest_activity = GuestActivity(
-        activity_id='A-00000001-20004'
-        ,record_id=1
-        ,user_mail = 'aaa@test.org'
-        ,file_name = "aaa.txt"
-        ,token="abc"
-        ,expiration_date=5
-        ,is_usage_report=False
-    )
-    with db.session.begin_nested():
-        db.session.add(activity1)
-        db.session.add(activity2)
-        db.session.add(activity3)
-        db.session.add(activity4)
-    db.session.commit()
-    with db.session.begin_nested():
-        db.session.add(activity1_next_action)
-        db.session.add(activity2_next_action)
-        db.session.add(activity3_next_action)
-        db.session.add(activity4_next_action)
-        db.session.add(activity1_pre_action)
-        db.session.add(activity2_pre_action)
-        db.session.add(activity3_pre_action)
-        db.session.add(activity4_pre_action)
-        db.session.add(file_permission)
-        db.session.add(guest_activity)
-    db.session.commit()
-    workflows.update({
-        "activity1":activity1
-        ,"activity2":activity2
-        ,"activity3":activity3
-        ,"activity4":activity4
-    })
-
-    permissions = list()
-    for i in range(len(users)):
-        permissions.append(FilePermission(users[i]["id"],"1.1","test_file","2",None,-1))
-    with db.session.begin_nested():
-        db.session.add_all(permissions)
-    db.session.commit()
-
-    def set_activityaction(_activity, _action,_flow_action):
-        action_handler = _activity.activity_login_user \
-            if not _action.action_endpoint == 'approval' else -1
-        activity_action = ActivityAction(
-            activity_id=_activity.activity_id,
-            action_id=_flow_action.action_id,
-            action_status="F",
-            action_handler=action_handler,
-            action_order=_flow_action.action_order
-        )
-        db.session.add(activity_action)
-
-    # setting activity_action in activity existed item
-    # for flow_action in flow_actions:
-    #     action = action_data[0][flow_action.action_id-1]
-    #     set_activityaction(activity_item1, action, flow_action)
-    #     set_activityaction(activity_item2, action, flow_action)
-    #     set_activityaction(activity_item3, action, flow_action)
-    #     set_activityaction(activity_item4, action, flow_action)
-    #     set_activityaction(activity_item5, action, flow_action)
-    #     set_activityaction(activity_item6, action, flow_action)
-
-    # db.session.commit()
-    return workflows
-    # {"flow_actions":flow_actions,
-    #         "activities":[activity,activity_item1,activity_item2,activity_item3,activity_item4,activity_item5,activity_item6]}
-
-
 @pytest.fixture()
 def db_register_approval(app, db, db_records, workflow_approval, users):
     """Register data for approval API in DB."""
@@ -5214,14 +4888,15 @@ def activity_with_roles(app, workflow, db, item_type, users):
 def activity_with_roles_for_request_mail(app, workflow, db, item_type, users):
     # flow action role
     flow_actions = workflow['flow_action']
+    repoadmin_role = Role.query.filter_by(name="Repository Administrator").one()
     flow_action_roles = [
         FlowActionRole(id = 1,
                     flow_action_id = flow_actions[2].id,
-                    action_role = 2,
+                    action_role = repoadmin_role.id,
                     action_role_exclude = False),
         FlowActionRole(id = 2,
                     flow_action_id = flow_actions[3].id,
-                    action_role = 2,
+                    action_role = repoadmin_role.id,
                     action_role_exclude = True),
         FlowActionRole(id = 3,
                     flow_action_id = flow_actions[4].id,
@@ -5983,7 +5658,7 @@ def application_api_request_body(app, item_type):
     return bodies
 
 @pytest.fixture()
-def indextree(client, users, app):
+def indextree(client, users, app, user_activity_log_partition_table):
     indicies = []
     index_metadata1 = {
         "id": 1001,
@@ -6160,10 +5835,9 @@ def make_record_restricted(db, indexer, id, index_id, item_type_id, userId):
         status=PIDStatus.REGISTERED,
     )
 
-    parent_id = PIDNodeVersioning(pid=parent).parents.one_or_none()
-    h1 = PIDNodeVersioning(pid=parent_id)
-    h1.insert_child(child=recid)
-    h1.insert_child(child=recid_v1)
+    h1 = PIDNodeVersioning(pid=parent)
+    h1.insert_child(recid)
+    h1.insert_child(recid_v1)
     PIDNodeDraft(pid=recid).insert_child(depid)
     PIDNodeDraft(pid=recid_v1).insert_child(depid_v1)
 
@@ -6376,3 +6050,30 @@ def db_mail_template_users(db, db_mail_templates):
     ]
 
     return mail_template, users, mail_template_users
+
+@pytest.fixture
+def user_activity_log_partition_table(app, db):
+    """Create user activity log partition."""
+    # Create partition for current month
+    now = datetime.now()
+    start = now.date().replace(day=1)
+    end = (start + timedelta(days=31)).replace(day=1)
+    partition_name = f"user_activity_logs_{now.year}_{now.month:02d}"
+    create_partition_sql = f"""
+        CREATE TABLE IF NOT EXISTS {partition_name}
+        PARTITION OF user_activity_logs
+        FOR VALUES FROM ('{start}') TO ('{end}');
+    """
+
+    with db.session.begin_nested():
+        db.session.execute(create_partition_sql)
+    db.session.commit()
+    return partition_name
+
+@pytest.fixture
+def mock_manifest(mocker):
+    mocker.patch(
+        "flask_webpackext.manifest.JinjaManifestLoader.load",
+        return_value={}
+    )
+

--- a/modules/weko-workflow/tests/helpers.py
+++ b/modules/weko-workflow/tests/helpers.py
@@ -22,6 +22,7 @@ from invenio_pidrelations.models import PIDRelation
 from invenio_records_files.api import Record
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus, Redirect, RecordIdentifier
 from invenio_pidstore.errors import PIDDoesNotExistError
+from invenio_pidrelations.utils import resolve_relation_type_config
 
 from weko_workflow.models import FlowDefine, FlowAction, FlowActionRole, WorkFlow, Activity, ActivityAction
 def json_data(filename):
@@ -86,12 +87,16 @@ def json_data(filename):
 def create_record(record_data, item_data):
     """Create a test record."""
     with db.session.begin_nested():
+        # resolve relation type
+        relation_type_version = resolve_relation_type_config("version")
+        relation_type_draft = resolve_relation_type_config("record_draft")
+
         record_data = copy.deepcopy(record_data)
         item_data = copy.deepcopy(item_data)
         rec_uuid = uuid.uuid4()
         recid = PersistentIdentifier.create('recid', record_data["recid"],object_type='rec', object_uuid=rec_uuid,status=PIDStatus.REGISTERED)
         depid = PersistentIdentifier.create('depid', record_data["recid"],object_type='rec', object_uuid=rec_uuid,status=PIDStatus.REGISTERED)
-        rel = PIDRelation.create(recid,depid,3)
+        rel = PIDRelation.create(recid, depid, relation_type_draft.id)
         db.session.add(rel)
         parent=None
         doi = None
@@ -101,13 +106,17 @@ def create_record(record_data, item_data):
                 PersistentIdentifier.get("doi",doi_url)
             except PIDDoesNotExistError:
                 doi = PersistentIdentifier.create('doi',doi_url,object_type='rec', object_uuid=rec_uuid,status=PIDStatus.REGISTERED)
-        if '.' in record_data["recid"]:
+        record_recid = record_data["recid"]
+        if '.' in record_recid:
             parent = PersistentIdentifier.get("recid",int(float(record_data["recid"])))
             recid_p = PIDRelation.get_child_relations(parent).one_or_none()
-            PIDRelation.create(recid_p.parent, recid,2)
+            relation_type = relation_type_draft if record_recid.endswith('.0') else relation_type_version
+            PIDRelation.create(recid_p.parent, recid, relation_type.id)
         else:
             parent = PersistentIdentifier.create('parent', "parent:{}".format(record_data["recid"]),object_type='rec', object_uuid=rec_uuid,status=PIDStatus.REGISTERED)
-            rel = PIDRelation.create(parent, recid,2,0)
+            rel = PIDRelation.create(
+                parent, recid, relation_type_version.id, index=0
+            )
             db.session.add(rel)
             RecordIdentifier.next()
         record = WekoRecord.create(record_data, id_=rec_uuid)

--- a/modules/weko-workflow/tests/test_activity.py
+++ b/modules/weko-workflow/tests/test_activity.py
@@ -1275,7 +1275,10 @@ class TestHeadlessActivity:
 
     # def _upload_files(self, files=None):
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_activity.py::TestHeadlessActivity::test__upload_files -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test__upload_files(self, app, db, workflow, users, client, mocker):
+    def test__upload_files(
+        self, app, db, workflow, users, client,
+        user_activity_log_partition_table, mocker
+    ):
         activity = HeadlessActivity()
         activity._deposit = {"_buckets": {"deposit": uuid.uuid4()}}
         mocker.patch.object(Bucket, "query", new=Mock())
@@ -1345,7 +1348,10 @@ class TestHeadlessActivity:
 
     # def _delete_file(self, version_ids):
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_activity.py::TestHeadlessActivity::test__delete_file -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test__delete_file(self, app, db, workflow, users, client, mocker):
+    def test__delete_file(
+        self, app, db, workflow, users, client,
+        user_activity_log_partition_table, mocker
+    ):
         version_ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
 
         mock_get = mocker.patch("weko_workflow.headless.activity.ObjectVersion.get")

--- a/modules/weko-workflow/tests/test_admin.py
+++ b/modules/weko-workflow/tests/test_admin.py
@@ -117,20 +117,24 @@ class TestFlowSettingView:
                 mock_args=mocker.patch("flask.templating._render",return_value=make_response())
                 url = '/admin/flowsetting/{}'.format(flow_define.flow_id)
                 res =  client.get(url)
-                args,kwargs = mock_args.call_args
+                args, kwargs = mock_args.call_args
+                # args = (Flask, Template, Context)
+                _, _, context = args
                 assert res.status_code == status_code
-                assert args[1]['actions'][0].action_role.specify_property== "test"
-                assert args[1]['actions'][0].action_role.action_item_registrant == True
+                assert context['actions'][0].action_role.specify_property== "test"
+                assert context['actions'][0].action_role.action_item_registrant == True
 
         with patch("weko_admin.models.AdminSettings.get",return_value={"edit_mail_templates_enable": False,"display_request_form": False}):
             with patch("weko_workflow.api.Flow.get_flow_detail", return_value=mock_flow):
                 mock_args=mocker.patch("flask.templating._render",return_value=make_response())
                 url = '/admin/flowsetting/{}'.format(flow_define.flow_id)
                 res =  client.get(url)
-                args,kwargs = mock_args.call_args
+                args, kwargs = mock_args.call_args
+                # args = (Flask, Template, Context)
+                _, _, context = args
                 assert res.status_code == status_code
-                assert args[1]['actions'][0].action_role.specify_property== None
-                assert args[1]['actions'][0].action_role.action_item_registrant == False
+                assert context['actions'][0].action_role.specify_property== None
+                assert context['actions'][0].action_role.action_item_registrant == False
 
     # def flow_detail(self, flow_id='0'):
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestFlowSettingView::test_flow_detail_return_repositories -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
@@ -142,7 +146,8 @@ class TestFlowSettingView:
             res =  client.get(url)
             assert res.status_code == 200
             args, kwargs = mock_render.call_args
-            assert len(args[1]["repositories"]) == 2
+            # Note: args = (Flask, Template, context)
+            assert len(args[2]["repositories"]) == 2
 
         url = '/admin/flowsetting/{}'.format(0)
         login(client=client, email=users[3]['email'])
@@ -150,7 +155,8 @@ class TestFlowSettingView:
             res =  client.get(url)
             assert res.status_code == 200
             args, kwargs = mock_render.call_args
-            assert len(args[1]["repositories"]) == 1
+            # Note: args = (Flask, Template, context)
+            assert len(args[2]["repositories"]) == 1
 
     # def flow_detail(self, flow_id='0'):
     # def new_flow(self, flow_id='0'):
@@ -212,7 +218,8 @@ class TestFlowSettingView:
         with patch("flask.templating._render", return_value=b"") as mock_render:
             response = client.get('/admin/flowsetting/0')
             args, kwargs = mock_render.call_args
-            context = args[1]
+            # args = (Flask, Template, Context)
+            _, _, context = args
             filtered_role_names = [role.name for role in context['roles']]
             assert "jc_xxx_roles_contributor" not in filtered_role_names
             assert "jc_xxx_groups_yyy" in filtered_role_names
@@ -227,86 +234,98 @@ class TestFlowSettingView:
 #     def update_flow(flow_id):
 #     def new_flow(self, flow_id='0'):
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestFlowSettingView::test_new_flow -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_new_flow(self,app,client,action_data,users):
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(0)
+    def test_new_flow(self, app, client, action_data, users, mocker):
+        repoadmin_user_email = users[1]["email"]
+        mocker.patch("flask.templating._render", return_value="dummy")
+        login(client=client, email=repoadmin_user_email)
+
+        # Check that no flows exist initially
         q = FlowDefine.query.all()
         assert len(q) == 0
 
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url)
+        # Test: Create a new flow with exception raised in the Flow class
+        with patch(
+            "weko_workflow.admin.Flow.create_flow",
+            side_effect=Exception("Simulated error")
+        ):
+            new_flow_url = url_for("flowsetting.new_flow", flow_id=str(0))
+            res =  client.post(new_flow_url, json={})
             assert res.status_code == 500
         q = FlowDefine.query.all()
         assert len(q) == 0
 
+        # Test: Create a new flow with missing required fields
         data = {"flow": "test1"}
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(0)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url, data=json.dumps(data), headers=[('Content-Type', 'application/json')])
-            assert res.status_code == 400
+        login(client=client, email=repoadmin_user_email)
+        new_flow_url = url_for("flowsetting.new_flow", flow_id=str(0))
+        res =  client.post(new_flow_url, json=data)
+        assert res.status_code == 400
         q = FlowDefine.query.all()
         assert len(q) == 0
 
+        # Test: Create a new flow with valid data
         data = {"flow_name": "test1", "repository_id": "Root Index"}
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(0)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url, data=json.dumps(data), headers=[('Content-Type', 'application/json')])
-            assert res.status_code == 200
+        login(client=client, email=repoadmin_user_email)
+        new_flow_url = url_for("flowsetting.new_flow", flow_id=str(0))
+        res =  client.post(new_flow_url, json=data)
+        assert res.status_code == 200
         q = FlowDefine.query.all()
         assert len(q) == 1
 
+        # Test: Attempt to create a duplicate flow with the same name and repository
         data = {"flow_name": "test1", "repository_id": "Root Index"}
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(0)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url, data=json.dumps(data), headers=[('Content-Type', 'application/json')])
-            assert res.status_code == 400
+        login(client=client, email=repoadmin_user_email)
+        new_flow_url = url_for("flowsetting.new_flow", flow_id=str(0))
+        res =  client.post(new_flow_url, json=data)
+        assert res.status_code == 400
         q = FlowDefine.query.all()
         assert len(q) == 1
 
+        # Test: Update the existing flow with a new name
         flow_id = q[0].flow_id
         data = {"flow_name": "test2", "repository_id": "Root Index"}
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(flow_id)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url, data=json.dumps(data), headers=[('Content-Type', 'application/json')])
-            assert res.status_code == 200
+        login(client=client, email=repoadmin_user_email)
+        new_flow_url = url_for("flowsetting.new_flow", flow_id=str(flow_id))
+        res =  client.post(new_flow_url, json=data)
+        assert res.status_code == 200
         q = FlowDefine.query.first()
         assert q.flow_name == 'test2'
 
+        # Test: Attempt to update the flow with invalid data (missing required fields)
         data = {"flow": "test3"}
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(flow_id)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url, data=json.dumps(data), headers=[('Content-Type', 'application/json')])
-            assert res.status_code == 400
+        login(client=client, email=repoadmin_user_email)
+        new_flow_url = url_for("flowsetting.new_flow", flow_id=flow_id)
+        res =  client.post(new_flow_url, json=data)
+        assert res.status_code == 400
         q = FlowDefine.query.first()
         assert q.flow_name == 'test2'
 
+        # Test: Create a new flow with the same name and repository as an existed flow
         data = {"flow_name": "test1", "repository_id": "Root Index"}
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(0)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url, data=json.dumps(data), headers=[('Content-Type', 'application/json')])
-            assert res.status_code == 200
+        login(client=client, email=repoadmin_user_email)
+        new_flow_url = url_for("flowsetting.new_flow", flow_id=0)
+        res =  client.post(new_flow_url, json=data)
+        assert res.status_code == 200
         q = FlowDefine.query.all()
         assert len(q) == 2
 
+        # Test: Attempt to update the existing flow with a name that already exists for another flow
         data = {"flow_name": "test1", "repository_id": "Root Index"}
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(flow_id)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url, data=json.dumps(data), headers=[('Content-Type', 'application/json')])
-            assert res.status_code == 400
+        login(client=client, email=repoadmin_user_email)
+        new_flow_url = url_for("flowsetting.new_flow", flow_id=flow_id)
+        res =  client.post(new_flow_url, json=data)
+        assert res.status_code == 400
         q = FlowDefine.query.first()
         assert q.flow_name == 'test2'
 
-        login(client=client, email=users[1]['email'])
-        url = '/admin/flowsetting/{}'.format(flow_id)
-        with patch("flask.templating._render", return_value=""):
-            res =  client.post(url)
+        # Test: Simulate an exception during the update process
+        login(client=client, email=repoadmin_user_email)
+        with mocker.patch(
+            "weko_workflow.admin.Flow.upt_flow",
+            side_effect=Exception("Simulated error")
+        ):
+            new_flow_url = url_for("flowsetting.new_flow", flow_id=flow_id)
+            res =  client.post(new_flow_url, json={})
             assert res.status_code == 500
         q = FlowDefine.query.first()
         assert q.flow_name == 'test2'
@@ -508,7 +527,11 @@ class TestWorkFlowSettingView:
         (5, 403),
         (6, 200),
     ])
-    def test_index_acl(self,client,db_register2,users,users_index,status_code):
+    def test_index_acl(
+        self, client, db_register2, users, users_index, status_code, mocker
+    ):
+        # mock render_template
+        mocker.patch("flask_admin.base.render_template", return_value="dummy")
         login(client=client, email=users[users_index]['email'])
         url = url_for('workflowsetting.index',_external=True)
         res =  client.get(url)
@@ -541,7 +564,7 @@ class TestWorkFlowSettingView:
         res = client.get(url)
         assert res.status_code == 200
         args, kwargs = mock_render.call_args
-        context = args[1]
+        context = args[2]
         display_names = context['workflows'][0].display.replace(',<br>', ',').split(',')
         assert "jc_xxx_roles_contributor" not in display_names
         assert "test_role" in display_names
@@ -564,7 +587,10 @@ class TestWorkFlowSettingView:
         # (5, 200),
         # (6, 200),
     ])
-    def test_workflow_detail_acl(self,app ,client,db_register_full_action,workflow_open_restricted, db_register2,users,users_index,status_code,mocker):
+    def test_workflow_detail_acl(
+        self, app, client, db_register_full_action, workflow_open_restricted,
+        db_register2, users, users_index, status_code, mocker
+    ):
         login(client=client, email=users[users_index]['email'])
         url = url_for('workflowsetting.workflow_detail',workflow_id='0',_external=True)
         mock_render =mocker.patch("flask.templating._render", return_value=make_response())
@@ -572,8 +598,9 @@ class TestWorkFlowSettingView:
         assert res.status_code == status_code
         is_sysadmin = users_index == 2
         args, kwargs = mock_render.call_args
+        render_context = args[2]
         # 81
-        assert args[1]["is_sysadmin"] == is_sysadmin
+        assert render_context["is_sysadmin"] == is_sysadmin
 
         wf:WorkFlow = workflow_open_restricted[0]["workflow"]
         flows_id = wf.flows_id
@@ -581,9 +608,10 @@ class TestWorkFlowSettingView:
         is_sysadmin = users_index == 2
         res =  client.get(url)
         args, kwargs = mock_render.call_args
-        assert args[1]["is_sysadmin"] == is_sysadmin
+        render_context = args[2]
+        assert render_context["is_sysadmin"] == is_sysadmin
         assert res.status_code == status_code
-        assert args[1]['is_display_restricted_access_checkbox'] == False
+        assert render_context['is_display_restricted_access_checkbox'] == False
 
         current_app.config.update(WEKO_ADMIN_RESTRICTED_ACCESS_DISPLAY_FLAG = True)
         url = url_for('workflowsetting.workflow_detail',workflow_id='0',_external=True)
@@ -592,8 +620,9 @@ class TestWorkFlowSettingView:
         assert res.status_code == status_code
         is_sysadmin = users_index == 2
         args, kwargs = mock_render.call_args
+        render_context = args[2]
         # 81
-        assert args[1]["is_sysadmin"] == is_sysadmin
+        assert render_context["is_sysadmin"] == is_sysadmin
 
         wf:WorkFlow = workflow_open_restricted[0]["workflow"]
         flows_id = wf.flows_id
@@ -601,13 +630,14 @@ class TestWorkFlowSettingView:
         is_sysadmin = users_index == 2
         res =  client.get(url)
         args, kwargs = mock_render.call_args
-        assert args[1]["is_sysadmin"] == is_sysadmin
+        render_context = args[2]
+        assert render_context["is_sysadmin"] == is_sysadmin
         if is_sysadmin:
             assert res.status_code == status_code
-            assert args[1]['is_display_restricted_access_checkbox'] == True
+            assert render_context['is_display_restricted_access_checkbox'] == True
         else:
             assert res.status_code == 403
-            assert args[1]['is_display_restricted_access_checkbox'] == False
+            assert render_context['is_display_restricted_access_checkbox'] == False
 
         #117
         wf:WorkFlow = db_register_full_action["workflow"]
@@ -619,19 +649,27 @@ class TestWorkFlowSettingView:
 
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestWorkFlowSettingView::test_workflow_detail_return_repositories -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
     def test_workflow_detail_return_repositories(self,app ,client, users, workflow, mocker):
-        login(client=client, email=users[2]['email'])
+        # System Administrator can see all repositories
+        sysadmin_user_email = users[2]["email"]
+        login(client=client, email=sysadmin_user_email)
         url = url_for('workflowsetting.workflow_detail',workflow_id='0')
         mock_render =mocker.patch("flask.templating._render", return_value=make_response())
-        res =  client.get(url)
+        _ =  client.get(url)
         args, kwargs = mock_render.call_args
-        assert len(args[1]["repositories"]) == 2
+        # Note: args = (Flask, Template, context)
+        render_context = args[2]
+        assert len(render_context["repositories"]) == 2
 
-        login(client=client, email=users[3]['email'])
+        # Community Administrator can see repositories they have access to
+        comadmin_user_email = users[3]["email"]
+        login(client=client, email=comadmin_user_email)
         url = url_for('workflowsetting.workflow_detail',workflow_id='0')
         mock_render =mocker.patch("flask.templating._render", return_value=make_response())
-        res =  client.get(url)
+        _ =  client.get(url)
         args, kwargs = mock_render.call_args
-        assert len(args[1]["repositories"]) == 1
+        # Note: args = (Flask, Template, context)
+        render_context = args[2]
+        assert len(render_context["repositories"]) == 2
 
 
     #     def update_workflow(self, workflow_id='0'):
@@ -648,8 +686,8 @@ class TestWorkFlowSettingView:
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestWorkFlowSettingView::test_update_workflow_acl -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
     @pytest.mark.parametrize('users_index, status_code', [
         # (0, 403),
-        (1, 200),
-        (2, 200),
+        (1, 200),   # Repository Administrator
+        (2, 200),   # System Administrator
         # (3, 200),
         # (4, 200),
         # (5, 200),
@@ -762,31 +800,53 @@ class TestWorkFlowSettingView:
 
     #     def update_workflow(self, workflow_id='0'):
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestWorkFlowSettingView::test_update_workflow -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_update_workflow(self,client,db,db_register2,users,workflow):
+    def test_update_workflow(
+        self, client, db, db_register2, users, workflow,
+        user_activity_log_partition_table
+    ):
         login(client=client, email=users[1]['email'])
         define = workflow["flow"]
         wflow : WorkFlow = workflow["workflow"]
-        url = url_for('workflowsetting.update_workflow',workflow_id=wflow.flows_id,_external=True)
+        url = url_for(
+            "workflowsetting.update_workflow",
+            workflow_id=wflow.flows_id, _external=True
+        )
         with patch("flask.templating._render", return_value=""):
-            res =  client.post(url
-                                , headers=[('Content-Type', 'application/json')
-                                            ,('Accept', 'application/json')]
-                                , data=json.dumps({'id': wflow.id,'flow_id': define.id
-                                                   })
-                                )
-            assert res.status_code == 200
+            response =  client.post(
+                url, headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                },
+                json={
+                    "id": wflow.id,
+                    "flow_id": define.id,
+                    "itemtype_id": wflow.itemtype_id,
+                    "is_gakuninrdm": False,
+                }
+            )
+            assert response.status_code == 200
             wf : WorkFlow = db.session.query(WorkFlow).filter_by(id = wflow.id).one_or_none()
             assert wf.open_restricted == False
 
-            url = url_for('workflowsetting.update_workflow',workflow_id='0',_external=True)
-            res =  client.post(url
-                                    , headers=[('Content-Type', 'application/json')
-                                                ,('Accept', 'application/json')]
-                                    , data=json.dumps({'id': wflow.id,'flow_id': define.id
-                                                    ,'itemtype_id' :wflow.itemtype_id
-                                                    ,'flows_id' : wflow.flows_id
-                                                    ,'is_gakuninrdm' : False})
-                                    )
+            url = url_for(
+                "workflowsetting.update_workflow",
+                workflow_id="0", _external=True
+            )
+            response =  client.post(
+                url, headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                },
+                json={
+                    "id": wflow.id,
+                    "flow_id": define.id,
+                    "itemtype_id": wflow.itemtype_id,
+                    "flows_id": wflow.flows_id,
+                    "is_gakuninrdm": False
+                }
+            )
+            assert response.status_code == 200
+
 
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestWorkFlowSettingView::test_workflow_detail_roles_filter -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
     def test_workflow_detail_roles_filter(self, client, db, users):
@@ -817,7 +877,8 @@ class TestWorkFlowSettingView:
         with patch("flask.templating._render", return_value=b"") as mock_render:
             response = client.get('/admin/workflowsetting/0')
             args, kwargs = mock_render.call_args
-            context = args[1]
+            # Note: args: Flask, Template, context, kwargs
+            context = args[2]
             filtered_role_names = [role.name for role in context['display_list']]
             assert "jc_xxx_roles_contributor" not in filtered_role_names
             assert "jc_xxx_groups_yyy" in filtered_role_names
@@ -912,16 +973,22 @@ class TestWorkFlowSettingView:
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestActivitySettingsView -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 class TestActivitySettingsView:
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestActivitySettingsView::test_index_get_request -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_index_get_request(self, client, db_register2, users):
+    def test_index_get_request(self, client, db_register2, users, mocker):
         """Test GET request for ActivitySettingsView.index."""
+        # mock render_template to avoid webpack issues during testing
+        mocker.patch("flask_admin.base.render_template", return_value="dummy")
         login(client=client, email=users[2]['email'])
         url = url_for("activity.index", _external=True)
         res = client.get(url)
         assert res.status_code == 200
 
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestActivitySettingsView::test_index_post_request_valid_form -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_index_post_request_valid_form(self, client, app, db_register2, users):
+    def test_index_post_request_valid_form(
+        self, client, app, db_register2, users, mocker
+    ):
         """Test POST request with valid form for ActivitySettingsView.index."""
+        # mock render_template to avoid webpack issues during testing
+        mocker.patch("flask_admin.base.render_template", return_value="dummy")
         login(client=client, email=users[2]['email'])
         app.config["WEKO_WORKFLOW_APPROVER_EMAIL_COLUMN_VISIBLE"] = True
         AdminSettings.update("activity_display_settings", {"activity_display_flg": "1"})
@@ -930,8 +997,12 @@ class TestActivitySettingsView:
         assert res.status_code == 200
 
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestActivitySettingsView::test_index_post_request_invalid_form -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_index_post_request_invalid_form(self, client, app, db_register2, users):
+    def test_index_post_request_invalid_form(
+        self, client, app, db_register2, users, mocker
+    ):
         """Test POST request with invalid form for ActivitySettingsView.index."""
+        # mock render_template to avoid webpack issues during testing
+        mocker.patch("flask_admin.base.render_template", return_value="dummy")
         login(client=client, email=users[2]['email'])
         app.config["WEKO_WORKFLOW_APPROVER_EMAIL_COLUMN_VISIBLE"] = True
         AdminSettings.update("activity_display_settings", {"activity_display_flg": "1"})
@@ -940,8 +1011,12 @@ class TestActivitySettingsView:
         assert res.status_code == 200
 
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestActivitySettingsView::test_index_activity_display_settings_not_found -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_index_activity_display_settings_not_found(self, client, app, db_register2, users):
+    def test_index_activity_display_settings_not_found(
+        self, client, app, db_register2, users, mocker
+    ):
         """Test GET request when activity_display_settings is not found."""
+        # mock render_template to avoid webpack issues during testing
+        mocker.patch("flask_admin.base.render_template", return_value="dummy")
         login(client=client, email=users[2]['email'])
         app.config["WEKO_WORKFLOW_APPROVER_EMAIL_COLUMN_VISIBLE"] = True
         AdminSettings.update("activity_display_settings", None)
@@ -984,16 +1059,24 @@ class TestWorkSpaceWorkFlowSettingView:
         (5, 403),
         (6, 200),
     ])
-    def test_index_acl(self,client,db_register2,users,users_index,status_code):
+    def test_index_acl(
+        self, client, db_register2, users, users_index, status_code, mocker
+    ):
+        # mock render_template to avoid webpack issues during testing
+        mocker.patch("flask_admin.base.render_template", return_value="dummy")
         login(client=client, email=users[users_index]['email'])
         url = url_for('workspaceworkflowsetting.index',_external=True)
         res =  client.get(url)
         assert res.status_code == status_code
 
     # .tox/c1/bin/pytest --cov=weko_workflow tests/test_admin.py::TestWorkSpaceWorkFlowSettingView::test_index -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-    def test_index(self,client,db,admin_settings,app,users,db_register2,mocker):
+    def test_index(
+        self, client, db, admin_settings, app, users, db_register2, mocker
+    ):
         from invenio_accounts.testutils import login_user_via_session
         from flask_wtf import FlaskForm,Form
+        # mock render_template to avoid webpack issues during testing
+        mocker.patch("flask_admin.base.render_template", return_value="dummy")
         login_user_via_session(client,email=users[2]["email"])
         url = url_for('workspaceworkflowsetting.index')
         res =  client.get(url)

--- a/modules/weko-workflow/tests/test_api.py
+++ b/modules/weko-workflow/tests/test_api.py
@@ -105,18 +105,23 @@ def test_Flow_get_flow_list(app, client, users, db, action_data):
         db.session.add(flow)
         db.session.commit()
 
-        login_user(users[2]["obj"])
+        # System administrator can see all flows
+        sysadmin_user = users[2]["obj"]
+        login_user(sysadmin_user)
         res = _flow.get_flow_list()
         assert len(res) == 1
         assert res[0] == flow
 
-        login_user(users[3]["obj"])
+        # Community administrator can see flows in their community
+        comadmin_user = users[3]["obj"]
+        login_user(comadmin_user)
         res = _flow.get_flow_list()
         assert len(res) == 0
-
-        flow_com = _flow.create_flow({'flow_name': 'flow_comm01', 'repository_id': 'comm01'})
-        db.session.add(flow_com)
-        db.session.commit()
+        # Create a flow in the community and check if the community administrator can see it
+        flow_com = _flow.create_flow({
+            "flow_name": "flow_comm01",
+            "repository_id": "comm01"
+        })
 
         res = _flow.get_flow_list()
         assert len(res) == 1
@@ -769,7 +774,9 @@ def test_WorkActivity_count_waiting_approval_by_workflow_id(app, db, db_register
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_api.py::test_WorkFlow_upt_workflow -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_WorkFlow_upt_workflow(app, db, workflow, logging_client, users):
+def test_WorkFlow_upt_workflow(
+    app, db, workflow, users, user_activity_log_partition_table
+):
     with app.test_request_context():
         # System Administrator
         login_user(users[2]["obj"])
@@ -1584,10 +1591,17 @@ def test_workactivity_get_params_for_approver(app, users, db, db_register_full_a
     index = Index(position=1, id=111)
     db.session.add(index)
     db.session.commit()
-    comm = Community(id="test_com11", id_role=users[3]["id"],
-                        id_user=users[3]["id"], title="test community",
-                        description="this is test community",
-                        root_node_id=index.id)
+    comadmin_user_id = users[3]["id"]
+    comadmin_user = User.query.get(comadmin_user_id)
+    comadmin_role = comadmin_user.roles[0]
+    comm = Community(
+        id="test_com11",
+        id_role=comadmin_role.id,
+        id_user=comadmin_user_id,
+        title="test community",
+        description="this is test community",
+        root_node_id=index.id
+    )
     db.session.add(comm)
     db.session.commit()
     flow_define = db_register_full_action["flow_define"]
@@ -1737,7 +1751,9 @@ def test_workactivity_get_params_for_approver(app, users, db, db_register_full_a
             patch("weko_workflow.api.GetCommunity.get_community_by_id") as mock_get_community_by_id:
         mock_user_profile = MagicMock(username="test_username")
         mock_get_user_profile.return_value = mock_user_profile
-        mock_get_community_by_id.return_value = MagicMock(id_role=4)
+        mock_get_community_by_id.return_value = MagicMock(
+            id_role="Community Administrator",
+        )
         mock_flow_detail = MagicMock(
             flow_actions=[_ for _ in flow_detail.flow_actions]
         )
@@ -2352,7 +2368,7 @@ def test_query_activities_by_tab_is_wait(users, db):
                 _WorkFlow.flows_name,
                 _Action.action_name,
                 Role.name
-            ).outerjoin(_Flow).outerjoin(
+            ).select_from(_Activity).outerjoin(_Flow).outerjoin(
                 _WorkFlow,
                 and_(_Activity.workflow_id == _WorkFlow.id,)
             ).outerjoin(_Action).outerjoin(_FlowAction).outerjoin(_FlowActionRole).outerjoin(
@@ -2367,7 +2383,7 @@ def test_query_activities_by_tab_is_wait(users, db):
                     _Activity.activity_update_user == User.id,
                     _Activity.shared_user_ids == [],
                 )
-                )
+            )
         expected = "AND (" \
                         "workflow_activity.activity_login_user = %(activity_login_user_1)s " \
                         "OR (CAST(workflow_activity.shared_user_ids AS VARCHAR) LIKE '%%' || %(param_1)s || '%%') " \
@@ -2554,14 +2570,23 @@ def test_WorkActivity_get_activity_action_role(app, activity_with_roles, action_
     (6, 3, 'allow', True),
     (5, 4, 'deny', True),
 ])
-def test_WorkActivity_get_activity_action_role2(app, activity_with_roles_for_request_mail, action_id, action_order, expected_index, expected_included):
+def test_WorkActivity_get_activity_action_role2(
+    app, activity_with_roles_for_request_mail, action_id, action_order, expected_index, expected_included
+):
     activity = activity_with_roles_for_request_mail["activity"]
     item_metadata = activity_with_roles_for_request_mail['itemMetadata']
     owner_id = int(item_metadata['owner'])
 
+    # Get repository administrator role
+    role_repoadmin = Role.query.filter_by(name="Repository Administrator").one()
+
     workflow_activity = WorkActivity()
     roles, _ = workflow_activity.get_activity_action_role(str(activity.id), action_id, action_order)
-    assert (owner_id in roles[expected_index]) == expected_included
+    # Check if the action role includes the repository administrator role
+    # Note: fixture `activity_with_roles_for_request_mail` should be set up to include the repository administrator role for the specified action_role
+    assert (
+        (role_repoadmin.id in roles[expected_index]) == expected_included
+    )
 
 # for request_mail
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_api.py::test_WorkActivity_get_activity_action_role3 -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
@@ -2717,29 +2742,42 @@ def test_request_mail_list_create_and_update(app, workflow, db, mocker):
 
 # def get_user_ids_of_request_mails_by_activity_id
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_api.py::test_get_user_ids_of_request_mails_by_activity_id -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_get_user_ids_of_request_mails_by_activity_id(workflow, users, mocker):
+def test_get_user_ids_of_request_mails_by_activity_id(
+    db, workflow, users, mocker
+):
+    # Get user ids of request mails by activity id
+    role_unassigned_user_id = users[7]["id"]
+    contributor_user_id = users[0]["id"]
+    
+    # Get users by user ids
+    role_unassigned_user = db.session.get(User, role_unassigned_user_id)
+    contributor_user = db.session.get(User, contributor_user_id)
+    
     activity = WorkActivity()
     activityrequestmails = [
         ActivityRequestMail(
-        id = 1,
-        activity_id = 1,
-        display_request_button = True,
-        request_maillist = []
-    ),
+            id=1,
+            activity_id=1,
+            display_request_button=True,
+            request_maillist=[]
+        ),
         ActivityRequestMail(
-            id = 2,
-            activity_id = 2,
-            display_request_button = False,
-            request_maillist = [{}]
-    ),
+            id=2,
+            activity_id=2,
+            display_request_button=False,
+            request_maillist=[{}]
+        ),
         ActivityRequestMail(
-            id = 3,
-            activity_id = 3,
-            display_request_button = True,
-            request_maillist = [{"email":"not_user","author_id":""},
-                                {"email":"user@test.org","author_id":""},
-                                {"email":"contributor@test.org","author_id":""}]
-    )]
+            id=3,
+            activity_id=3,
+            display_request_button=True,
+            request_maillist=[
+                {"email": "not_user", "author_id": ""},
+                {"email": role_unassigned_user.email, "author_id": ""},
+                {"email": contributor_user.email, "author_id": ""}
+            ]
+        )
+    ]
     with patch("weko_workflow.api.WorkActivity.get_activity_detail", return_value = _Activity(extra_info={"record_id":1, "is_restricted_access":True})):
         mock = mocker.patch("weko_workflow.api.WorkActivity.get_user_ids_of_request_mails_by_record_id")
         activity.get_user_ids_of_request_mails_by_activity_id(1)
@@ -2753,15 +2791,33 @@ def test_get_user_ids_of_request_mails_by_activity_id(workflow, users, mocker):
         assert activity.get_user_ids_of_request_mails_by_activity_id(2) == []
     with patch("weko_workflow.api.WorkActivity.get_activity_request_mail", return_value = activityrequestmails[2]):
         ids = activity.get_user_ids_of_request_mails_by_activity_id(3)
-        assert ids == [User.query.filter_by(email="contributor@test.org").one_or_none().id]
+        assert ids == [contributor_user_id]
+
 
 # def get_user_ids_of_request_mails_by_record_id
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_api.py::test_get_user_ids_of_request_mails_by_record_id -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_get_user_ids_of_request_mails_by_record_id(workflow, users, mocker):
+def test_get_user_ids_of_request_mails_by_record_id(
+    db, workflow, users, mocker
+):
+
+    # Get user ids of request mails by activity id
+    role_unassigned_user_id = users[7]["id"]
+    contributor_user_id = users[0]["id"]
+
+    # Get users by user ids
+    role_unassigned_user = db.session.get(User, role_unassigned_user_id)
+    contributor_user = db.session.get(User, contributor_user_id)
+
     activity = WorkActivity()
-    requestmails = [[],[{}],[{"email":"not_user","author_id":""},
-                                {"email":"user@test.org","author_id":""},
-                                {"email":"contributor@test.org","author_id":""}]]
+    requestmails = [
+        [],
+        [{}],
+        [
+            {"email": "not_user", "author_id" :""},
+            {"email": role_unassigned_user.email, "author_id": ""},
+            {"email": contributor_user.email, "author_id":""}
+        ]
+    ]
     mocker.patch("weko_workflow.api.PersistentIdentifier.get")
     mocker.patch("weko_workflow.api.PersistentIdentifier.get_assigned_object")
     with patch("weko_workflow.api.RequestMailList.get_mail_list_by_item_id", return_value=None):
@@ -2772,8 +2828,7 @@ def test_get_user_ids_of_request_mails_by_record_id(workflow, users, mocker):
         assert not activity.get_user_ids_of_request_mails_by_record_id(0)
     with patch("weko_workflow.api.RequestMailList.get_mail_list_by_item_id", return_value=requestmails[2]):
         ids = activity.get_user_ids_of_request_mails_by_record_id(0)
-        assert ids == [User.query.filter_by(email="contributor@test.org").one_or_none().id]
-
+        assert ids == [contributor_user_id]
 
 
 # def check_user_role_for_mail

--- a/modules/weko-workflow/tests/test_rest.py
+++ b/modules/weko-workflow/tests/test_rest.py
@@ -23,9 +23,10 @@
 import copy
 from datetime import datetime
 
-from flask import json, current_app
+from flask import json, current_app, url_for
 from mock import patch, MagicMock
 import pytest
+from pytest import fail
 
 from invenio_accounts.models import Role
 from invenio_communities.models import Community
@@ -37,7 +38,10 @@ def url(root, kwargs = {}):
     return url
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_rest.py::test_GetActivities_get -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_GetActivities_get(app, client, db, db_register_activity, auth_headers, users):
+def test_GetActivities_get(
+    app, client, db, db_register_activity, auth_headers, users,
+    without_remove_session
+):
 
     # test preparation
     path = '/v1/workflow/activities'
@@ -120,9 +124,15 @@ def test_GetActivities_get(app, client, db, db_register_activity, auth_headers, 
 
     # Match Etag : 304
     param6 = copy.deepcopy(param)
-    param6['limit'] = '10'
-    res = client.get(url(path, param6), headers=headers_sysadmin)
-    assert res.status_code == 304
+    # param6['limit'] = '10'
+    # Convert list of tuples to dictionary for easier manipulation
+    headers_sysadmin = dict(headers_sysadmin)
+    with patch(
+        "weko_workflow.rest.generate_etag",
+        return_value=headers_sysadmin["If-None-Match"]
+    ):
+        res = client.get(url(path, param6), headers=headers_sysadmin)
+        assert res.status_code == 304
 
     # Normal : 200
     res = client.get(url(path, param), headers=headers_sysadmin)
@@ -144,7 +154,10 @@ def test_GetActivities_get(app, client, db, db_register_activity, auth_headers, 
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_rest.py::test_ApproveActivity_post -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_ApproveActivity_post(app, client, db, db_register_approval, auth_headers, users):
+def test_ApproveActivity_post(
+    app, client, db, db_register_approval, auth_headers, users,
+    without_remove_session
+):
     """Test ApproveActivity.post method."""
 
     current_app.config['WEKO_WORKFLOW_ENABLE_CONTRIBUTOR'] = False
@@ -212,7 +225,10 @@ def test_ApproveActivity_post(app, client, db, db_register_approval, auth_header
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_rest.py::test_ThrowOutActivity_post -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_ThrowOutActivity_post(app, client, db, db_register_approval, auth_headers, users):
+def test_ThrowOutActivity_post(
+    app, client, db, db_register_approval, auth_headers, users,
+    without_remove_session
+):
     """Test ThrowOutActivity.post method."""
 
     current_app.config['WEKO_WORKFLOW_ENABLE_CONTRIBUTOR'] = False
@@ -277,8 +293,11 @@ def test_ThrowOutActivity_post(app, client, db, db_register_approval, auth_heade
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_rest.py::test_FileApplicationActivity_post -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_FileApplicationActivity_post(app, client, db, db_register_for_application_api,
-                                      auth_headers, users, application_api_request_body, indextree, records_restricted,mocker):
+def test_FileApplicationActivity_post(
+    app, client, db, db_register_for_application_api, auth_headers,
+    users, application_api_request_body, indextree, records_restricted,
+    without_remove_session, mocker
+):
     """Test FileApplicationActivity.post method."""
 
     activity_id = db_register_for_application_api['activity1'].activity_id
@@ -299,78 +318,103 @@ def test_FileApplicationActivity_post(app, client, db, db_register_for_applicati
     activity1_extra_info = db_register_for_application_api['activity1'].extra_info
     mock_task = mocker.patch("weko_deposit.tasks.extract_pdf_and_update_file_contents")
     mock_task.apply_async = MagicMock()
-    
+
+    # Create valid url for file_application_activity endpoint
+    valid_fileapp_activity_url = url_for(
+        "weko_workflow_rest.file_application_activity",
+        version=version,
+        activity_id=activity_id,
+        _external=True
+    )
+    valid_mock_request_body = {"aaa":"123"}
+    actual_request_body = application_api_request_body[1]
+
     # WEKO_RECORDS_UI_RESTRICTED_API = False : 403 error
-    params = {"index_ids": index1["id"]}
-    body = application_api_request_body[0]
+    current_app.config.update(WEKO_RECORDS_UI_RESTRICTED_API = False)
     res_check = 0   # OK
     with patch('weko_workflow.rest.check_authority_action', return_value=res_check):
         with patch("weko_handle.api.Handle.register_handle",return_value="handle:00.000.12345/0000000001"):
+            fileapp_activity_url = url_for(
+                "weko_workflow_rest.file_application_activity",
+                version=version,
+                activity_id=activity_id,
+                index_ids=index1["id"],
+                _external=True
+            )
             res = client.post(
-                url(f'/{version}/workflow/activities/{activity_id}/application', params),
-                data=json.dumps(body),
-                content_type='application/json',
+                fileapp_activity_url,
+                json=application_api_request_body[0],
                 headers=headers_student,
             )
     assert res.status_code == 403
 
+    # Reset WEKO_RECORDS_UI_RESTRICTED_API to True for the following tests
     current_app.config.update(WEKO_RECORDS_UI_RESTRICTED_API = True)
 
     # Invalid version : 400 error
-    body = {"aaa":"123"}
+    invalid_version_fileapp_activity_url = url_for(
+        "weko_workflow_rest.file_application_activity",
+        version=invalid_version,    # Invalid version
+        activity_id=activity_id,
+        _external=True
+    )
     res = client.post(
-        f'/{invalid_version}/workflow/activities/{activity_id}/application',
-        data=json.dumps(body),
-        content_type='application/json',
+        invalid_version_fileapp_activity_url,
+        json=valid_mock_request_body,
         headers=headers_sysadmin,
     )
     assert res.status_code == 400
     try:
         json.loads(res.get_data())
     except:
-        assert False
+        fail("Failed to parse JSON response")
 
     # request body is empty : 400 error
-    body = {}
     res = client.post(
-        f'/{version}/workflow/activities/{activity_id}/application',
-        data=json.dumps(body),
-        content_type='application/json',
+        valid_fileapp_activity_url,
+        json={},    # Empty request body
         headers=headers_sysadmin,
     )
     assert res.status_code == 400
     try:
         json.loads(res.get_data())
     except:
-        assert False
+        fail("Failed to parse JSON response")
 
     # Guest: Invalid token : 400 error
-    params = {"token": "aaa"}
-    body = {"aaa":"123"}
-    token_valid = False
-    with patch('weko_workflow.rest.validate_guest_activity_token', return_value=(token_valid, guest_activity_id, "guest@example.org")):
+    token_validation_result = False
+    with patch(
+        "weko_workflow.rest.validate_guest_activity_token",
+        return_value=(
+            token_validation_result, guest_activity_id, "guest@example.org"
+        )
+    ):
+        fileapp_activity_url = url_for(
+            "weko_workflow_rest.file_application_activity",
+            version=version,
+            activity_id=guest_activity_id,
+            token="dummy_token",
+            _external=True
+        )
         res = client.post(
-            url(f'/{version}/workflow/activities/{guest_activity_id}/application', params),
-            data=json.dumps(body),
-            content_type='application/json',
+            fileapp_activity_url,
+            json={"body": "dummy"},
             headers=headers_not_login,
         )
     assert res.status_code == 400
     try:
         json.loads(res.get_data())
     except:
-        assert False
+        fail("Failed to parse JSON response")
 
     # Guest: Expired token : 400 error
     params = {"token": "aaa"}
-    body = {"aaa":"123"}
     token_valid = True
     with patch('weko_workflow.rest.validate_guest_activity_token', return_value=(token_valid, guest_activity_id, "guest@example.org")):
         with patch('weko_workflow.rest.validate_guest_activity_expired', return_value="The specified link has expired."):
             res = client.post(
                 url(f'/{version}/workflow/activities/{guest_activity_id}/application', params),
-                data=json.dumps(body),
-                content_type='application/json',
+                json=valid_mock_request_body,
                 headers=headers_not_login,
             )
     assert res.status_code == 400
@@ -381,13 +425,11 @@ def test_FileApplicationActivity_post(app, client, db, db_register_for_applicati
 
     # Invalid enum : 400 error
     params = {}
-    body = application_api_request_body[1]
     res_check = 0   # OK
     with patch('weko_workflow.rest.check_authority_action', return_value=res_check):
         res = client.post(
             url(f'/{version}/workflow/activities/{activity_id}/application', params),
-            data=json.dumps(body),
-            content_type='application/json',
+            json=actual_request_body,
             headers=headers_student,
         )
     assert res.status_code == 400
@@ -410,8 +452,7 @@ def test_FileApplicationActivity_post(app, client, db, db_register_for_applicati
             with patch('weko_workflow.rest.get_main_record_detail', return_value=record_detail_alt):
                 res = client.post(
                     url(f'/{version}/workflow/activities/{with_index_guest_activity_id}/application', params),
-                    data=json.dumps(body),
-                    content_type='application/json',
+                    json=application_api_request_body[1],
                     headers=headers_not_login,
                 )
     assert res.status_code == 400

--- a/modules/weko-workflow/tests/test_utils.py
+++ b/modules/weko-workflow/tests/test_utils.py
@@ -207,7 +207,9 @@ def test_get_identifier_setting(identifier):#c
 
 # def saving_doi_pidstore(item_id,
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_saving_doi_pidstore -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_saving_doi_pidstore(db_records,item_type,mocker):#c
+def test_saving_doi_pidstore(
+    db_records, item_type, user_activity_log_partition_table, mocker
+):#c
     item_id = db_records[0][3].id
     pid_without_ver = get_record_without_version(db_records[0][0]).object_uuid
     mock_register = mocker.patch("weko_workflow.utils.IdentifierHandle.register_pidstore", return_value=None)
@@ -690,7 +692,7 @@ def test_handle_check_required_data(db_records, item_type):#c
 
 # def handle_check_required_pattern_and_either(mapping_data, mapping_keys,
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_handle_check_required_pattern_and_either -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_handle_check_required_pattern_and_either(db,item_type):
+def test_handle_check_required_pattern_and_either(db, item_type, location):
     # mapping_data is None, mapping_key is None
     result = handle_check_required_pattern_and_either(None,None,None)
     assert result == None
@@ -1090,7 +1092,7 @@ def test_convert_record_to_item_metadata(db_records, db_itemtype):
 
 # def prepare_edit_workflow(post_activity, recid, deposit):
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-@pytest.mark.parametrize("order_if",[0, 1, 2, 3, 4, 5])
+@pytest.mark.parametrize("order_if",[0, 1, 2, 3, 4, 5, 6])
 def test_prepare_edit_workflow(app, workflow, db_records,users,mocker, order_if):
     #login(client=client, email=users[2]["email"])
     with app.test_request_context():
@@ -1144,9 +1146,9 @@ def test_prepare_edit_workflow(app, workflow, db_records,users,mocker, order_if)
             deposit = db_records[6][6]
             res = prepare_edit_workflow(data,recid,deposit)
             assert res.activity_id != None
-
-        mocker.patch("weko_workflow.utils.IdentifierHandle.get_pidstore")
-        with patch("weko_deposit.api.WekoRecord.get_record_by_pid", return_value=None):
+        elif order_if == 6:
+            # mocker.patch("weko_workflow.utils.IdentifierHandle.get_pidstore")
+            # with patch("weko_deposit.api.WekoRecord.get_record_by_pid", return_value=None):
             recid = db_records[4][0]
             deposit = db_records[4][6]
             res = prepare_edit_workflow(data,recid,deposit)
@@ -1417,281 +1419,6 @@ def test_prepare_edit_workflow_pidstore_exception(app, workflow, db_records, use
 
                 action_identifier = ActionIdentifier.query.filter_by(activity_id=rtn.activity_id).first()
                 assert action_identifier.action_identifier_select == 0
-
-
-        mocker.patch("weko_workflow.utils.IdentifierHandle.get_pidstore")
-        with patch("weko_deposit.api.WekoRecord.get_record_by_pid", return_value=None):
-            recid = db_records[4][0]
-            deposit = db_records[4][6]
-            res = prepare_edit_workflow(data,recid,deposit)
-            assert res.activity_id != None
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_existing_draft_pid_and_bucket -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_existing_draft_pid_and_bucket(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        recid = db_records[3][0]
-        deposit = db_records[3][6]
-
-        # 52716-2 existing draft pid and bucket
-        res = prepare_edit_workflow(data, recid, deposit)
-        assert res.item_id != None
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_existing_draft_pid_no_bucket -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_existing_draft_pid_no_bucket(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        draft_pid = db_records[12][0]
-        deposit = db_records[12][6]
-
-        before_count_bucket = Bucket.query.count()
-        before_count_records_buckets = RecordsBuckets.query.count()
-
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-
-        mocker.patch("invenio_deposit.api.Deposit.files")
-        create_bucket_mock = mocker.patch("invenio_files_rest.models.Bucket.create")
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        mocker.patch("invenio_files_rest.models.Bucket.get" , return_value=None)
-
-        # 52716-3 existing draft pid but no bucket
-        with patch("invenio_records_files.models.RecordsBuckets.create", side_effect=SQLAlchemyError("Test Exception")) as create_records_buckets_mock:
-            with pytest.raises(SQLAlchemyError) as excinfo:
-                prepare_edit_workflow(data, draft_pid, deposit)
-
-                assert create_bucket_mock.called
-                assert create_records_buckets_mock.called
-                assert str(ex) == "Test Exception"
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_check_doi -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_check_doi(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-        draft_pid = db_records[3][0]
-        deposit = db_records[3][6]
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        mock_pid_doi = MagicMock()
-        # 52716-4 pid_doi.status == PIDStatus.DELETED
-        mock_pid_doi.status = PIDStatus.DELETED
-        with patch("weko_workflow.utils.IdentifierHandle.get_pidstore", return_value=mock_pid_doi):
-            rtn = prepare_edit_workflow(data, draft_pid, deposit)
-
-            action_identifier = ActionIdentifier.query.filter_by(activity_id=rtn.activity_id).first()
-            assert action_identifier.action_identifier_select == -3
-
-        # 52716-5 pid_doi.status is not PIDStatus.DELETED
-        mock_pid_doi.status = PIDStatus.REGISTERED
-        with patch("weko_workflow.utils.IdentifierHandle.get_pidstore", return_value=mock_pid_doi):
-            rtn = prepare_edit_workflow(data, draft_pid, deposit)
-
-            action_identifier = ActionIdentifier.query.filter_by(activity_id=rtn.activity_id).first()
-            assert action_identifier.action_identifier_select == -1
-
-        # 52716-6 pid_doi is None
-        mock_pid_doi = None
-        with patch("weko_workflow.utils.IdentifierHandle.get_pidstore", return_value=mock_pid_doi):
-            rtn = prepare_edit_workflow(data, draft_pid, deposit)
-
-            action_identifier = ActionIdentifier.query.filter_by(activity_id=rtn.activity_id).first()
-            assert action_identifier.action_identifier_select == 0
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_existing_feedbackmail -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_existing_feedbackmail(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        recid = db_records[3][0]
-        deposit = db_records[3][6]
-
-        # 52716-7 feedbackmail exists
-        with patch("weko_workflow.utils.FeedbackMailList.get_mail_list_by_item_id", return_value=["test@example.com"]):
-            mock_create_or_update_action_feedbackmail = mocker.patch("weko_workflow.api.WorkActivity.create_or_update_action_feedbackmail")
-            res = prepare_edit_workflow(data, recid, deposit)
-
-            assert mock_create_or_update_action_feedbackmail.called
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_rtn_none -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_rtn_none(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        recid = db_records[3][0]
-        deposit = db_records[3][6]
-
-        # 52716-9 failed init_activity
-        with patch("weko_workflow.api.WorkActivity.init_activity", return_value=None):
-            res = prepare_edit_workflow(data, recid, deposit)
-
-            assert res is None
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_exception -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_exception(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        draft_pid = db_records[3][0]
-        deposit = db_records[3][6]
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-        # 52716-10 raises SQLAlchemyError
-        with patch("weko_workflow.utils.WekoDeposit.commit", side_effect=SQLAlchemyError("Test Exception")):
-            with pytest.raises(SQLAlchemyError) as excinfo:
-                prepare_edit_workflow(data, draft_pid, deposit)
-            assert str(excinfo.value) == "Test Exception"
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_draft_item_exception -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_draft_item_exception(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-        draft_pid = db_records[2][0]
-        deposit = db_records[2][6]
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        # 52716-11 failed prepare_draft_item
-        mocker.patch("weko_deposit.api.WekoDeposit.prepare_draft_item", return_value=None)
-        with pytest.raises(AttributeError) as excinfo:
-            prepare_edit_workflow(data, draft_pid, deposit)
-        assert "object has no attribute" in str(excinfo.value)
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_get_record_exception -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_get_record_exception(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-        draft_pid = db_records[3][0]
-        deposit = db_records[3][6]
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        # 52716-12 failed get_record
-        mocker.patch("weko_deposit.api.WekoDeposit.get_record", return_value=None)
-        with pytest.raises(AttributeError) as excinfo:
-            prepare_edit_workflow(data, draft_pid, deposit)
-        assert "object has no attribute" in str(excinfo.value)
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_convert_item_exception -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_convert_item_exception(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-        draft_pid = db_records[12][0]
-        deposit = db_records[12][6]
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        # 52716-13 failed convert_record_to_item_metadata
-        with pytest.raises(KeyError) as excinfo:
-            prepare_edit_workflow(data, draft_pid, deposit)
-        assert isinstance(excinfo.value, KeyError)
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_edit_workflow_pidstore_exception -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_prepare_edit_workflow_pidstore_exception(app, workflow, db_records, users, mocker):
-    with app.test_request_context():
-        login_user(users[2]["obj"])
-        mocker.patch("weko_workflow.utils.WekoDeposit.update")
-        mocker.patch("weko_workflow.utils.WekoDeposit.commit")
-        mocker.patch("weko_workflow.utils.WekoDeposit.publish")
-        draft_pid = db_records[3][0]
-        deposit = db_records[3][6]
-        data = {
-            "flow_id": workflow["flow"].id,
-            "workflow_id": workflow["workflow"].id,
-            "community": 1,
-            "itemtype_id": 1,
-            "activity_login_user": 1,
-            "activity_update_user": 1
-        }
-        # 52716-14 failed get_pidstore
-        with patch("weko_workflow.utils.get_parent_pid_with_type", side_effect=PIDDoesNotExistError("recid", draft_pid.pid_value)):
-            with pytest.raises(PIDDoesNotExistError):
-                rtn = prepare_edit_workflow(data, draft_pid, deposit)
-
-                action_identifier = ActionIdentifier.query.filter_by(activity_id=rtn.activity_id).first()
-                assert action_identifier.action_identifier_select == 0
-
 
 
 # def prepare_edit_workflow(post_activity, recid, deposit):
@@ -1781,12 +1508,15 @@ def test_prepare_delete_workflow(app, db_records,users,db_register_full_action,m
 
 # def handle_finish_workflow(deposit, current_pid, recid):
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_handle_finish_workflow -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_handle_finish_workflow(workflow, db_records, mocker, db_itemtype2):
+def test_handle_finish_workflow(
+    workflow, db_records, user_activity_log_partition_table,
+    db_itemtype2, mocker
+):
     result = handle_finish_workflow(None, None, None)
     assert result == None
     mocker.patch("weko_deposit.api.WekoDeposit.publish")
     mocker.patch("weko_deposit.api.WekoDeposit.commit")
-    mocker.patch("invenio_oaiserver.tasks.update_records_sets.delay")
+    # mocker.patch("invenio_oaiserver.tasks.update_records_sets.delay")
 
     deposit = db_records[2][6]
     current_pid = db_records[2][0]
@@ -1818,12 +1548,14 @@ def test_handle_finish_workflow(workflow, db_records, mocker, db_itemtype2):
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_handle_finish_workflow2 -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_handle_finish_workflow2(workflow, db_records, item_type, mocker):
+def test_handle_finish_workflow2(
+    workflow, db_records, item_type, user_activity_log_partition_table, mocker
+):
     result = handle_finish_workflow(None, None, None)
     assert result == None
     mocker.patch("weko_deposit.api.WekoDeposit.publish")
     mocker.patch("weko_deposit.api.WekoDeposit.commit")
-    mocker.patch("invenio_oaiserver.tasks.update_records_sets.delay")
+    # mocker.patch("invenio_oaiserver.tasks.update_records_sets.delay")
 
     deposit = db_records[2][6]
     current_pid = db_records[2][0]
@@ -1859,12 +1591,14 @@ def test_handle_finish_workflow2(workflow, db_records, item_type, mocker):
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_handle_finish_workflow_external_system -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_handle_finish_workflow_external_system(workflow, db_records, mocker):
+def test_handle_finish_workflow_external_system(
+    workflow, db_records, user_activity_log_partition_table, mocker
+):
     record = WekoRecord.get_record_by_pid("1")
     deposit = WekoDeposit(record, record.model)
     mocker.patch("weko_deposit.api.WekoDeposit.publish")
     mocker.patch("weko_workflow.utils.UpdateItem.publish")
-    mocker.patch("invenio_oaiserver.tasks.update_records_sets.delay")
+    # mocker.patch("invenio_oaiserver.tasks.update_records_sets.delay")
     mocker.patch("weko_workflow.utils.WekoRecord.get_record_by_pid", return_value=record)
     mocker.patch("weko_deposit.api.WekoDeposit.newversion", MagicMock())
     mocker.patch("weko_workflow.utils.ItemReference.get_src_references", return_value=MagicMock())
@@ -1985,7 +1719,7 @@ def test_get_cache_data(client):
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_check_an_item_is_locked -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_check_an_item_is_locked(app):
     with app.app_context():
-        with patch("weko_workflow.utils.inspect") as mock_inspect:
+        with patch("weko_workflow.utils.current_celery_app.control.inspect") as mock_inspect:
             mock_inspect_instance = mock_inspect.return_value
             # inspect(timeout=_timeout).ping()
             mock_inspect_instance.ping.return_value = True
@@ -2892,6 +2626,8 @@ def test_get_default_mail_sender(db):
 
     result = get_default_mail_sender()
     assert result == "test_sender"
+
+
 # def set_mail_info(item_info, activity_detail, guest_user=False):
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_set_mail_info -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_set_mail_info(app, db_register_full_action, mocker, records_restricted, db_records, db):
@@ -3017,19 +2753,17 @@ def test_set_mail_info(app, db_register_full_action, mocker, records_restricted,
     with app.test_request_context():
        record = WekoRecord.get_record(db_records[0][2].id)
        with patch("weko_workflow.utils.WekoRecord.get_record_by_pid", return_value = record):
-           with patch("weko_workflow.utils.url_for", return_value = 'records/1'):
-                result = set_mail_info(item_info,db_register_full_action["activities"][9],False)
-                assert result["landing_url"] != ""
+            result = set_mail_info(item_info,db_register_full_action["activities"][9],False)
+            assert result["landing_url"] != ""
 
     with app.test_request_context():
         record = WekoRecord.get_record(db_records[0][2].id)
         with patch("weko_workflow.utils.WekoRecord.get_record_by_pid", return_value = record):
-            with patch("weko_workflow.utils.url_for", return_value = 'records/1'):
-                with patch("weko_workflow.utils.WekoRecord.get_file_data", return_value = [{"filename":"aaa.txt"}]):
-                    with patch("weko_workflow.utils.extract_term_description", return_value=("","")):
-                        result = set_mail_info(item_info,db_register_full_action["activities"][10],False)
-                        assert result["terms_of_use_jp"] == ""
-                        assert result["terms_of_use_en"] == ""
+            with patch("weko_workflow.utils.WekoRecord.get_file_data", return_value = [{"filename":"aaa.txt"}]):
+                with patch("weko_workflow.utils.extract_term_description", return_value=("","")):
+                    result = set_mail_info(item_info,db_register_full_action["activities"][10],False)
+                    assert result["terms_of_use_jp"] == ""
+                    assert result["terms_of_use_en"] == ""
 
     with app.test_request_context():
         record = WekoRecord.get_record(db_records[0][2].id)
@@ -3058,17 +2792,15 @@ def test_set_mail_info(app, db_register_full_action, mocker, records_restricted,
     with app.test_request_context():
         record = WekoRecord.get_record(db_records[0][2].id)
         with patch("weko_workflow.utils.WekoRecord.get_record_by_pid", return_value = record):
-            with patch("weko_workflow.utils.url_for", return_value = 'records/1'):
-                with patch("weko_workflow.utils.extract_term_description", return_value=("test_terms_ja","test_terms_en")):
-                    result = set_mail_info(item_info,db_register_full_action["activities"][11],False)
+            with patch("weko_workflow.utils.extract_term_description", return_value=("test_terms_ja","test_terms_en")):
+                result = set_mail_info(item_info,db_register_full_action["activities"][11],False)
 
     with app.test_request_context():
         record = WekoRecord.get_record(db_records[0][2].id)
         with patch("weko_workflow.utils.WekoRecord.get_record_by_pid", return_value = ""):
-            # with patch("weko_workflow.utils.url_for", return_value = 'records/1'):
-                with patch("weko_workflow.utils.WekoRecord.get_file_data", return_value = [{"filename":"aaa.txt"}]):
-                    with patch("weko_workflow.utils.extract_term_description", return_value=("","")):
-                        result = set_mail_info(item_info,db_register_full_action["activities"][10],False)
+            with patch("weko_workflow.utils.WekoRecord.get_file_data", return_value = [{"filename":"aaa.txt"}]):
+                with patch("weko_workflow.utils.extract_term_description", return_value=("","")):
+                    result = set_mail_info(item_info,db_register_full_action["activities"][10],False)
 
 class MockDict():
     def __init__(self, data):
@@ -5191,7 +4923,7 @@ def test_get_record_first_version(db_register_full_action,db_records):
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_utils.py::test_prepare_doi_link_workflow -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_prepare_doi_link_workflow(app):
     app.config["PRESERVE_CONTEXT_ON_EXCEPTION"] = False
-    with app.test_request_context(data={}):
+    with app.test_request_context(json={}):
         doi_identifier = Identifier(id=1, repository='Root Index',jalc_flag= True,jalc_crossref_flag= True,jalc_datacite_flag=True,ndl_jalc_flag=True,
             jalc_doi='123',jalc_crossref_doi='1234',jalc_datacite_doi='12345',ndl_jalc_doi='123456',suffix='suffix_',
             created_userId='1',created_date=datetime.datetime.strptime('2022-09-28 04:33:42','%Y-%m-%d %H:%M:%S'),

--- a/modules/weko-workflow/tests/test_views.py
+++ b/modules/weko-workflow/tests/test_views.py
@@ -74,7 +74,10 @@ def test_index_acl_nologin(client,db_register2):
     (6, 200, False, True),
 ])
 # def test_index_acl(client, users, db_register2,users_index, status_code):
-def test_index_acl(client, users, db_register2, mocker, app, users_index, status_code, enable_show_activity, approver_email_visible):
+def test_index_acl(
+    client, users, db_register2, mocker, app, without_remove_session,
+    users_index, status_code, enable_show_activity, approver_email_visible
+):
     app.config['WEKO_WORKFLOW_ENABLE_SHOW_ACTIVITY'] = enable_show_activity
     app.config['WEKO_WORKFLOW_COLUMNS'] = ['approver_email'] if approver_email_visible else []
     app.config['WEKO_WORKFLOW_APPROVER_EMAIL_COLUMN_VISIBLE'] = approver_email_visible
@@ -300,7 +303,7 @@ def test_iframe_success(client, db_register_full_action,users, db_records,mocker
             assert mock_kwargs["error"] == "can not get data required for rendering"
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_new_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_new_activity(client, db, users, mocker):
+def test_new_activity(client, db, users, without_remove_session, mocker):
     login(client=client, email=users[0]['email'])
 
     with patch("weko_workflow.views.WorkFlow.get_workflow_list", return_value=['wf1', 'wf2']), \
@@ -393,7 +396,10 @@ def test_init_activity_acl_nologin(client,db_register2):
     (5, 200),
     (6, 200),
 ])
-def test_init_activity_acl(app, client, users, users_index, status_code, item_type, workflow):
+def test_init_activity_acl(
+    app, client, users, item_type, workflow, without_remove_session,
+    users_index, status_code
+):
     """_summary_
 
     Args:
@@ -554,13 +560,13 @@ def test_init_activity_acl(app, client, users, users_index, status_code, item_ty
     q = ActivityAction.query.all()
     assert len(q) == 21
 
+    # test for showing term of use
     app.config['WEKO_WORKFLOW_ENABLE_SHOWING_TERM_OF_USE'] = True
     app.config['WEKO_ITEMS_UI_SHOW_TERM_AND_CONDITION'] = ['テストアイテムタイプ']
     url = url_for('weko_workflow.init_activity')
     input = {
         'workflow_id': workflow_id,
         'flow_id': flow_def_id,
-        'unknown':'unknown',
         'itemtype_id': item_type_id,
         'extra_info': {'test': 'test'},
         'related_title': 'aaa',
@@ -581,6 +587,7 @@ def test_init_activity_acl(app, client, users, users_index, status_code, item_ty
     assert len(q) == 4
     q = ActivityAction.query.all()
     assert len(q) == 28
+    app.config['WEKO_WORKFLOW_ENABLE_SHOWING_TERM_OF_USE'] = False
 
     url = url_for('weko_workflow.init_activity')
     input = {'workflow_id': workflow_id, 'flow_id': flow_def_id}
@@ -611,7 +618,10 @@ def test_init_activity_acl(app, client, users, users_index, status_code, item_ty
     (5, 200),
     (6, 200),
 ])
-def test_init_activity(client, users, users_index, status_code, db_register_1, mocker):
+def test_init_activity(
+    client, users, db_register_1, without_remove_session,
+    users_index, status_code, mocker
+):
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.init_activity')
     mocker.patch("weko_workflow.views.is_terms_of_use_only",return_value=False)
@@ -654,8 +664,14 @@ def test_init_activity_is_terms_of_use_only(app, client,users, db_register_1):
     # 94
     with patch("weko_workflow.views.is_terms_of_use_only",return_value=True):
         # with patch("weko_workflow.views._generate_download_url",return_value='record/1/files/test_file'):
-            input = {'workflow_id': db_register_1['workflow'].id, 'flow_id': db_register_1['flow_define'].id, 'unknown':'unknown'
-                    ,'extra_info':{'file_name' : 'test_file' , "record_id" : "1"}}
+            input = {
+                "workflow_id": db_register_1["workflow"].id,
+                "flow_id": db_register_1['flow_define'].id,
+                "extra_info":{
+                    "file_name" : "test_file",
+                    "record_id" : "1"
+                }
+            }
             res = client.post(url, json=input)
             assert res.status_code == 200
             data = json.loads(res.data)
@@ -732,12 +748,20 @@ def test_list_activity_acl(client, users, mocker, users_index, status_code):
 
 # def init_activity_guest():
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_init_activity_guest_nologin -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_init_activity_guest_nologin(client,db_register2, mocker):
+def test_init_activity_guest_nologin(
+    client, db_register2, without_remove_session, mocker
+):
     """Test init activity for guest user."""
     url = url_for('weko_workflow.init_activity_guest')
-    input = {'guest_mail': 'test@guest.com', 'workflow_id': 1, 'flow_id': 1,
-            'item_type_id': 1, 'record_id': '1', 'guest_item_title': 'test',
-            'file_name': 'test_file'}
+    input = {
+        "guest_mail": "test@guest.com",
+        "workflow_id": 1,
+        "flow_id": 1,
+        "item_type_id": 1,
+        "record_id": "1",
+        "guest_item_title": "test",
+        "file_name": "test_file"
+    }
     with patch("weko_workflow.views.is_terms_of_use_only",return_value=False):
         with patch('weko_workflow.views.init_activity_for_guest_user', return_value=(WorkActivity(), 'url')):
             with patch('weko_workflow.views.db.session.commit'):
@@ -850,46 +874,47 @@ def test_display_guest_activity_item_application(db_register, client):
 
 # def display_guest_activity_item_application():
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_render_guest_workflow -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_render_guest_workflow(client, users, db_register_full_action, db_guestactivity):
+def test_render_guest_workflow(client, users, db_register_full_action, db_guestactivity, mocker):
     url = "/activity/guest-user/file_name?token=token"
     mock_render_template = MagicMock(return_value=jsonify({}))
     client.get(url)
-    return_validate_guest_activity_token = (False, None, None)
+
+    # Create a mock for validate_guest_activity_token to return False
+    mock_validate_guest_activity_token = mocker.patch(
+        "weko_workflow.views.validate_guest_activity_token"
+    )
+    mock_validate_guest_activity_token.return_value = (False, None, None)
     with patch('weko_workflow.views.GuestActivity.get_expired_activities',return_value=""):
-        with patch('weko_workflow.views.validate_guest_activity_token',return_value=return_validate_guest_activity_token):
+        with patch('weko_workflow.views.render_template', mock_render_template):
+            render_guest_workflow("file_name")
+            mock_render_template.assert_called()
+
+    mock_validate_guest_activity_token.return_value = (True, None, None)
+    with patch('weko_workflow.views.GuestActivity.get_expired_activities',return_value=""):
+        with patch('weko_workflow.views.validate_guest_activity_expired', return_value ="error"):
             with patch('weko_workflow.views.render_template', mock_render_template):
-                res = render_guest_workflow("file_name")
+                render_guest_workflow("file_name")
                 mock_render_template.assert_called()
 
-    return_validate_guest_activity_token = (True, None, None)
+    mock_validate_guest_activity_token.return_value = (True, None, None)
     with patch('weko_workflow.views.GuestActivity.get_expired_activities',return_value=""):
-        with patch('weko_workflow.views.validate_guest_activity_token',return_value=return_validate_guest_activity_token):
-            with patch('weko_workflow.views.validate_guest_activity_expired', return_value ="error"):
-                with patch('weko_workflow.views.render_template', mock_render_template):
-                    res = render_guest_workflow("file_name")
-                    mock_render_template.assert_called()
+        with patch('weko_workflow.views.validate_guest_activity_expired', return_value =""):
+            with patch('weko_workflow.views.prepare_data_for_guest_activity',return_value={"steps": [1]}):
+                with patch('weko_workflow.views.get_usage_data',return_value={}):
+                    with patch('weko_workflow.views.get_main_record_detail',return_value={"record":{"is_guest":True}}):
+                        with patch('weko_workflow.views.render_template', mock_render_template):
+                            render_guest_workflow("file_name")
+                            mock_render_template.assert_called()
 
-    return_validate_guest_activity_token = (True, None, None)
+    mock_validate_guest_activity_token.return_value = (True, None, None)
     with patch('weko_workflow.views.GuestActivity.get_expired_activities',return_value=""):
-        with patch('weko_workflow.views.validate_guest_activity_token',return_value=return_validate_guest_activity_token):
-            with patch('weko_workflow.views.validate_guest_activity_expired', return_value =""):
-                with patch('weko_workflow.views.prepare_data_for_guest_activity',return_value={}):
-                    with patch('weko_workflow.views.get_usage_data',return_value={}):
-                        with patch('weko_workflow.views.get_main_record_detail',return_value={"record":{"is_guest":True}}):
-                            with patch('weko_workflow.views.render_template', mock_render_template):
-                                res = render_guest_workflow("file_name")
-                                mock_render_template.assert_called()
-
-    return_validate_guest_activity_token = (True, None, None)
-    with patch('weko_workflow.views.GuestActivity.get_expired_activities',return_value=""):
-        with patch('weko_workflow.views.validate_guest_activity_token',return_value=return_validate_guest_activity_token):
-            with patch('weko_workflow.views.validate_guest_activity_expired', return_value =""):
-                with patch('weko_workflow.views.prepare_data_for_guest_activity',return_value={}):
-                    with patch('weko_workflow.views.get_usage_data',return_value={}):
-                        with patch('weko_workflow.views.get_main_record_detail',return_value={}):
-                            with patch('weko_workflow.views.render_template', mock_render_template):
-                                res = render_guest_workflow("file_name")
-                                mock_render_template.assert_called()
+        with patch('weko_workflow.views.validate_guest_activity_expired', return_value =""):
+            with patch('weko_workflow.views.prepare_data_for_guest_activity',return_value={"steps": [1]}):
+                with patch('weko_workflow.views.get_usage_data',return_value={}):
+                    with patch('weko_workflow.views.get_main_record_detail',return_value={}):
+                        with patch('weko_workflow.views.render_template', mock_render_template):
+                            render_guest_workflow("file_name")
+                            mock_render_template.assert_called()
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_find_doi_nologin -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
@@ -928,103 +953,19 @@ def test_find_doi_users(client, users, users_index, status_code):
 def test_save_activity_acl_nologin(client, db):
     """Test of save activity."""
     url = url_for('weko_workflow.save_activity')
-    input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":[]}
+    input = {
+        "activity_id":"A-20220921-00001",
+        "title":"test",
+        "shared_user_ids":[]
+    }
 
     res = client.post(url, json=input)
     assert res.status_code == 302
-    assert res.location == url_for('security.login',next="/workflow/save_activity_data",_external=True)
-
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity_acl_users -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-@pytest.mark.parametrize('users_index, status_code', [
-    (0, 200),
-    (1, 200),
-    (2, 200),
-    (3, 200),
-    (4, 200),
-    (5, 200),
-    (6, 200),
-])
-def test_save_activity_acl_users(client, users, users_index, status_code):
-    """Test of save activity."""
-    login(client=client, email=users[users_index]['email'])
-    url = url_for('weko_workflow.save_activity')
-    input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":[]}
-    with patch('weko_workflow.views.save_activity_data'):
-        res = client.post(url, json=input)
-        assert res.status_code != 302
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity_acl_guestlogin -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_save_activity_acl_guestlogin(guest):
-    input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":[]}
-    url = url_for('weko_workflow.save_activity')
-
-    res = guest.post(url, json=input)
-    assert res.status_code != 302
-
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-@pytest.mark.parametrize('users_index, status_code', [
-    (0, 200),
-    (1, 200),
-    (2, 200),
-    (3, 200),
-    (4, 200),
-    (5, 200),
-    (6, 200),
-])
-def test_save_activity(client, users, db_register_full_action, users_index, status_code):
-    login(client=client, email=users[users_index]['email'])
-    url = url_for('weko_workflow.save_activity')
-
-    input = {"activity_id":"A-20220921-00001","title":"test"}
-    res = client.post(url, json=input)
-    data = response_data(res)
-    assert res.status_code== 400
-    assert data["code"] == -1
-    assert data["msg"] == "{'shared_user_ids': ['Missing data for required field.']}"
-
-    input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":[]}
-    with patch('weko_workflow.views.save_activity_data'):
-        res = client.post(url, json=input)
-        data = response_data(res)
-        assert res.status_code==status_code
-        assert data["success"] == True
-        assert data["msg"] == ""
-
-    with patch('weko_workflow.views.save_activity_data', side_effect=Exception("test error")):
-        res = client.post(url, json=input)
-        data = response_data(res)
-        assert res.status_code==status_code
-        assert data["success"] == False
-        assert data["msg"] == "test error"
-
-#guestuserでの機能テスト
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity_guestlogin -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_save_activity_guestlogin(guest):
-    url = url_for('weko_workflow.save_activity')
-
-    input = {"activity_id":"A-20220921-00001","title":"test"}
-    res = guest.post(url, json=input)
-    data = response_data(res)
-    assert res.status_code== 400
-    assert data["code"] == -1
-    assert data["msg"] == "{'shared_user_ids': ['Missing data for required field.']}"
-
-    input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":[]}
-    with patch('weko_workflow.views.save_activity_data'):
-        res = guest.post(url, json=input)
-        data = response_data(res)
-        assert res.status_code==200
-        assert data["success"] == True
-        assert data["msg"] == ""
-
-    with patch('weko_workflow.views.save_activity_data', side_effect=Exception("test error")):
-        res = guest.post(url, json=input)
-        data = response_data(res)
-        assert res.status_code==200
-        assert data["success"] == False
-        assert data["msg"] == "test error"
+    assert res.location == url_for(
+        'security.login',
+        next="/workflow/save_activity_data",
+        _external=True
+    )
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_feedback_maillist_users -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
@@ -1063,7 +1004,10 @@ def test_save_feedback_maillist_users(client, users, db_register_full_action, us
     (1, 200)
 ])
 #.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_request_maillist -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_save_request_maillist(client,users, db_register_full_action, users_index, status_code):
+def test_save_request_maillist(
+    client,users, db_register_full_action, without_remove_session,
+    users_index, status_code
+):
     login(client=client, email=users[users_index]['email'])
     input = {
         'request_maillst':[],
@@ -1101,7 +1045,10 @@ def test_save_request_maillist(client,users, db_register_full_action, users_inde
     (1, 200)
 ])
 #.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_item_application -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_save_item_application(client,users, db_register_full_action, users_index, status_code):
+def test_save_item_application(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code
+):
     login(client=client, email=users[users_index]['email'])
     input_with_description = {
         'workflow_for_item_application':"1",
@@ -1148,11 +1095,6 @@ def test_display_guest_activity(client,mocker, db):
     display_guest_activity("test.txt")
     render_mock.assert_called()
 
-#.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_display_guest_activity_item_application -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_display_guest_activity_item_application(client,mocker, db):
-    render_mock = mocker.patch("weko_workflow.views.render_guest_workflow")
-    display_guest_activity_item_application("test.txt")
-    render_mock.assert_called()
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_previous_action_acl_nologin -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_previous_action_acl_nologin(client,db_register2):
@@ -1176,7 +1118,10 @@ def test_previous_action_acl_nologin(client,db_register2):
     (5, 403, False),
     (6, 403, True),
 ])
-def test_previous_action_acl_users(client, users, db_register_full_action, users_index, status_code, is_admin):
+def test_previous_action_acl_users(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code, is_admin
+):
     current_app.config.setdefault('THEME_INSTITUTION_NAME', {'ja':"組織", 'en':"INSTITUTION"})
     """Test of previous action."""
     login(client=client, email=users[users_index]['email'])
@@ -1242,7 +1187,10 @@ def test_previous_action_acl_users(client, users, db_register_full_action, users
     (5, 200),
     (6, 200),
 ])
-def test_previous_action(client, users, db_register_full_action, users_index, status_code):
+def test_previous_action(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code
+):
     current_app.config.setdefault('THEME_INSTITUTION_NAME', {'ja':"組織", 'en':"INSTITUTION"})
 
     login(client=client, email=users[users_index]['email'])
@@ -1387,7 +1335,10 @@ def test_next_action_acl_nologin(client, db_register_fullaction):
     (5, 200, False),
     (6, 200, True),
 ])
-def test_next_action_acl_users(client, users, db_register_fullaction, users_index, status_code, is_admin):
+def test_next_action_acl_users(
+    client, users, db_register_fullaction, without_remove_session,
+    users_index, status_code, is_admin
+):
     """Test of next action."""
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.next_action',
@@ -1470,6 +1421,7 @@ def test_next_action_acl_guestlogin(guest, client, db_register_fullaction):
         res = guest.post(url, json=input)
         assert res.status_code != 403
 
+
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_next_action -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 @pytest.mark.parametrize('users_index, status_code', [
     (0, 200),
@@ -1480,7 +1432,11 @@ def test_next_action_acl_guestlogin(guest, client, db_register_fullaction):
     (5, 200),
     (6, 200),
 ])
-def test_next_action(app, client, db, users, db_register_fullaction, db_records, users_index, status_code, mocker,logging_client):
+def test_next_action(
+    app, client, db, users, db_register_fullaction, db_records,
+    user_activity_log_partition_table, without_remove_session,
+    users_index, status_code, mocker
+):
     current_app.config.update(
         WEKO_NOTIFICATIONS=False
         )
@@ -1528,7 +1484,6 @@ def test_next_action(app, client, db, users, db_register_fullaction, db_records,
     mocker.patch("weko_deposit.api.WekoDeposit.merge_data_to_record_without_version",return_value=db_records[0][6])
     mocker.patch("weko_deposit.api.WekoDeposit.commit",return_value=True)
     mocker.patch("weko_workflow.api.UpdateItem.publish",return_value=True)
-    mocker.patch("invenio_oaiserver.tasks.update_records_sets.delay",return_value=True)
 
     flow_action_5 = db_register_fullaction["flow_actions"][5].id
     item_id1 = db_register_fullaction["activities"][0].item_id
@@ -2310,7 +2265,7 @@ def test_next_action(app, client, db, users, db_register_fullaction, db_records,
         data = response_data(res)
         result_status = 500 if check_role_approval() else 200
         result_code = -1 if check_role_approval() else 403
-        result_msg = "can not get curretn_flow_action" if check_role_approval() else noauth_msg
+        result_msg = "can not get current_flow_action" if check_role_approval() else noauth_msg
         assert res.status_code == result_status
         assert data["code"] == result_code
         assert data["msg"] == result_msg
@@ -2966,11 +2921,16 @@ def test_next_action(app, client, db, users, db_register_fullaction, db_records,
         assert res.status_code == status_code
         assert data["code"] == 0
         assert data["msg"] == "success"
+
+
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_next_action_usage_application -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 @pytest.mark.parametrize('users_index, status_code', [
     (0, 200)
 ])
-def test_next_action_usage_application(client, db, users, db_register_usage_application, db_records, users_index, status_code, mocker):
+def test_next_action_usage_application(
+    client, db, users, db_register_usage_application, db_records,
+    without_remove_session, users_index, status_code, mocker
+):
     def update_activity_order(activity_id, action_id, action_order):
         with db.session.begin_nested():
             activity=Activity.query.filter_by(activity_id=activity_id).one_or_none()
@@ -3041,7 +3001,10 @@ def test_next_action_usage_application(client, db, users, db_register_usage_appl
     (6, 200),
 ])
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_next_action_for_request_mail -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_next_action_for_request_mail(app, client, db, users, db_register_request_mail, db_records, users_index, status_code, mocker):
+def test_next_action_for_request_mail(
+    app, client, db, users, db_register_request_mail, db_records,
+    without_remove_session, users_index, status_code, mocker
+):
     def update_activity_order(activity_id, action_id, action_order):
         with db.session.begin_nested():
             activity=Activity.query.filter_by(activity_id=activity_id).one_or_none()
@@ -3163,7 +3126,10 @@ def test_cancel_action_acl_nologin(client,db_register2):
     (5, 403, False),
     (6, 403, True),
 ])
-def test_cancel_action_acl_users(client, users, db_register_full_action, users_index, status_code, is_admin):
+def test_cancel_action_acl_users(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code, is_admin
+):
     """Test of cancel action."""
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.cancel_action',
@@ -3231,6 +3197,8 @@ def test_cancel_action_acl_guestlogin(guest, db_register_full_action):
                return_value=(roles, action_users)):
         res = guest.post(url, json=input)
         assert res.status_code != 403
+
+
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_cancel_action -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 @pytest.mark.parametrize('users_index, status_code', [
     # (0, 200),
@@ -3241,7 +3209,10 @@ def test_cancel_action_acl_guestlogin(guest, db_register_full_action):
     # (5, 200),
     (6, 200),
 ])
-def test_cancel_action(client, users,db, db_register_full_action, db_records, add_file, users_index, status_code, mocker):
+def test_cancel_action(
+    client, users,db, db_register_full_action, db_records, add_file,
+    without_remove_session, users_index, status_code, mocker
+):
     login(client=client, email=users[users_index]['email'])
     #mocker.patch("weko_workflow.views.remove_file_cancel_action")
     # argument error
@@ -3277,7 +3248,10 @@ def test_cancel_action(client, users,db, db_register_full_action, db_records, ad
     (5, 200),
     (6, 200),
 ])
-def test_cancel_action2(client, users,db, db_register_full_action, db_records, add_file, users_index, status_code, mocker):
+def test_cancel_action2(
+    client, users,db, db_register_full_action, db_records, add_file,
+    without_remove_session, users_index, status_code, mocker
+):
     login(client=client, email=users[users_index]['email'])
     with patch("weko_workflow.api.WorkActivity.get_activity_action_role",
            return_value=({'allow': []}, {'allow': []})):
@@ -3448,7 +3422,10 @@ def test_cancel_action2(client, users,db, db_register_full_action, db_records, a
     (5, 200),
     (6, 200),
 ])
-def test_cancel_action3(client, users,db, db_register_full_action, db_records, add_file, users_index, status_code, mocker):
+def test_cancel_action3(
+    client, users,db, db_register_full_action, db_records, add_file,
+    without_remove_session, users_index, status_code, mocker
+):
     """
     Test cancel_action add case
 
@@ -3579,58 +3556,9 @@ def test_unlocks_activity_acl(client, users, db_register2, users_index):
     res = client.post(url,data=data)
     assert res.status_code != 302
 
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_unlocks_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_unlocks_activity(client, users, db_register2):
-
-    activity_id="A-22000111-00001"
-    url = url_for("weko_workflow.unlocks_activity", activity_id=activity_id)
-    locked_value = "1-123456789"
-    user = users[2]
-    login(client=client, email=user["email"])
-
-    lock_key = "workflow_locked_activity_{}".format(activity_id)
-    user_lock_key = "workflow_userlock_activity_{}".format(user["id"])
-    current_cache.delete(lock_key)
-    current_cache.delete(user_lock_key)
-
-    data = json.dumps({"locked_value":locked_value, "is_opened":False})
-
-    # not locked
-    res = client.post(url, data=data)
-    assert res.status_code == 200
-    assert json.loads(res.data) == {"code": 200, "msg_lock":None, "msg_userlock":"Not unlock"}
-
-    # locked
-    current_cache.set(lock_key,locked_value)
-    current_cache.set(user_lock_key,activity_id)
-    res = client.post(url, data=data)
-    assert res.status_code == 200
-    assert json.loads(res.data) == {"code": 200, "msg_lock":"Unlock success", "msg_userlock":"User Unlock Success"}
-    assert current_cache.get(lock_key) == None
-    assert current_cache.get(user_lock_key) == None
-
-    current_cache.delete(lock_key)
-    current_cache.delete(user_lock_key)
-
-
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_unlocks_activity_nologin -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_unlocks_activity_nologin(client, db_register2):
-    url = url_for('weko_workflow.unlocks_activity',activity_id="A-22000111-00001")
-    res = client.post(url)
-    assert res.status_code == 302
-
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_unlocks_activity_acl -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-@pytest.mark.parametrize('users_index', [ i for i in range(7)])
-def test_unlocks_activity_acl(client, users, db_register2, users_index):
-    url = url_for('weko_workflow.unlocks_activity',activity_id="A-22000111-00001")
-    login(client=client, email=users[users_index]["email"])
-    data = json.dumps({"locked_value":"", "is_opened":False})
-    res = client.post(url,data=data)
-    assert res.status_code != 302
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_unlocks_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_unlocks_activity(client, users, db_register2):
+def test_unlocks_activity(client, users, db_register2, without_remove_session):
 
     activity_id="A-22000111-00001"
     url = url_for("weko_workflow.unlocks_activity", activity_id=activity_id)
@@ -3679,7 +3607,9 @@ def test_is_user_locked_acl(client, users, db_register2, users_index):
     assert res.status_code != 302
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_is_user_locked -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_is_user_locked(client,db_register_full_action, users):
+def test_is_user_locked(
+    client, db_register_full_action, users, without_remove_session
+):
     login(client=client, email=users[2]['email'])
     current_cache.delete("workflow_userlock_activity_5")
     url = url_for('weko_workflow.is_user_locked')
@@ -3716,7 +3646,9 @@ def test_user_lock_activity_acl(client, users, db_register2, users_index):
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_user_lock_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_user_lock_activity(client,db_register2, users, mocker):
+def test_user_lock_activity(
+    client, db_register2, users, without_remove_session, mocker
+):
     login(client=client, email=users[2]['email'])
     current_cache.delete("workflow_userlock_activity_5")
     mocker.patch("weko_workflow.views.validate_csrf_header")
@@ -3810,7 +3742,9 @@ def test_user_unlock_activity_acl(client,users,db_register2,users_index):
 
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_user_unlock_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_user_unlock_activity(client,users,db_register2,mocker):
+def test_user_unlock_activity(
+    client, users, db_register2, without_remove_session, mocker
+):
     url = url_for('weko_workflow.user_unlock_activity', activity_id='1')
     login(client=client, email=users[2]['email'])
     current_cache.set("workflow_userlock_activity_5","2")
@@ -3861,7 +3795,9 @@ def test_lock_activity_users(client, users, users_index, status_code):
             assert res.status_code != 302
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_lock_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_lock_activity(client, users,db_register_full_action, mocker):
+def test_lock_activity(
+    client, users,db_register_full_action, without_remove_session, mocker
+):
     """Test of lock activity."""
     mocker.patch("weko_workflow.views.validate_csrf_header")
     status_code = 200
@@ -4087,7 +4023,10 @@ def test_unlock_activity_acl_users(client, users, users_index, status_code):
     (5, 200),
     (6, 200),
 ])
-def test_unlock_activity(client, users, db_register_full_action, users_index, status_code):
+def test_unlock_activity(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code
+):
     current_cache.delete("workflow_locked_activity_1")
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.unlock_activity', activity_id='1')
@@ -4171,7 +4110,10 @@ def test_check_approval_acl_users(client, users, users_index, status_code):
     (5, 200),
     (6, 200),
 ])
-def test_check_approval(client, users, db_register_full_action, users_index, status_code):
+def test_check_approval(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code
+):
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.check_approval', activity_id='1')
     response = {
@@ -4244,15 +4186,15 @@ def test_get_feedback_maillist_acl_users(client, users, users_index, status_code
     #(5, 200),
     #(6, 200),
 ])
-def test_get_feedback_maillist(client, users, db_register_full_action, users_index, status_code):
+def test_get_feedback_maillist(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code
+):
     login(client=client, email=users[users_index]['email'])
 
     action_feedback_mail = db_register_full_action['action_feedback_mail']
     action_feedback_mail_1 = db_register_full_action['action_feedback_mail1']
     action_feedback_mail_2 = db_register_full_action['action_feedback_mail2']
-
-    print(action_feedback_mail)
-    print(vars(action_feedback_mail))
 
     url = url_for('weko_workflow.get_feedback_maillist', activity_id='1')
     with patch('weko_workflow.views.type_null_check', return_value=False):
@@ -4324,7 +4266,9 @@ def test_get_feedback_maillist(client, users, db_register_full_action, users_ind
 ])
 # def get_request_maillist(activity_id='0')
 #.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_get_request_maillist -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_get_request_maillist(client, users, users_index, status_code, mocker):
+def test_get_request_maillist(
+    client, users, without_remove_session, users_index, status_code, mocker
+):
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.get_request_maillist', activity_id='1')
     with patch('weko_workflow.views.type_null_check', return_value=False):
@@ -4432,7 +4376,9 @@ def test_get_request_maillist(client, users, users_index, status_code, mocker):
 ])
 # def get_item_application(activity_id='0')
 #.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_get_item_application -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-def test_get_item_application(client, users, users_index, status_code, mocker):
+def test_get_item_application(
+    client, users, without_remove_session, users_index, status_code, mocker
+):
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.get_item_application', activity_id='1')
 
@@ -4499,8 +4445,8 @@ def test_save_activity_acl_users(client, users, users_index, status_code):
         res = client.post(url, json=input)
         assert res.status_code != 302
 
-#.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity_acl_guestlogin -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-#save_activityは@login_required_customizeなのでguestuserloginのテストも必要
+# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity_acl_guestlogin -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
+# save_activityは@login_required_customizeなのでguestuserloginのテストも必要
 def test_save_activity_acl_guestlogin(guest,db_register2):
     input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":[]}
     url = url_for('weko_workflow.save_activity')
@@ -4509,7 +4455,7 @@ def test_save_activity_acl_guestlogin(guest,db_register2):
     assert res.status_code != 302
 
 
-#.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
+# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 @pytest.mark.parametrize('users_index, status_code', [
     (0, 200),
     (1, 200),
@@ -4519,14 +4465,18 @@ def test_save_activity_acl_guestlogin(guest,db_register2):
     (5, 200),
     (6, 200),
 ])
-def test_save_activity(client, users, db_register_full_action, users_index, status_code):
+def test_save_activity(
+    client, users, db_register_full_action, without_remove_session,
+    users_index, status_code
+):
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.save_activity')
 
+    # Test: Invalid type for 'shared_user_ids' (should be a list)
     input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":'hogehoge'}
     res = client.post(url, json=input)
     data = response_data(res)
-    assert res.status_code== 400
+    assert res.status_code == 400
     assert data["code"] == -1
     assert data["msg"] == "{'shared_user_ids': ['Not a valid list.']}"
 
@@ -4548,7 +4498,7 @@ def test_save_activity(client, users, db_register_full_action, users_index, stat
 
 #.tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_save_activity_guestlogin -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 # guestuserでの機能テスト
-def test_save_activity_guestlogin(guest,db_register2):
+def test_save_activity_guestlogin(guest, db_register2):
     url = url_for('weko_workflow.save_activity')
 
     input = {"activity_id":"A-20220921-00001","title":"test","shared_user_ids":'hogehoge'}
@@ -4574,7 +4524,10 @@ def test_save_activity_guestlogin(guest,db_register2):
         assert data["msg"] == "test error"
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_verify_deletion -v -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko_workflow/.tox/c1/tmp
-def test_verify_deletion(client, db, db_register2,db_register_full_action,users):
+def test_verify_deletion(
+    client, db, db_register2, db_register_full_action,
+    users, without_remove_session
+):
     flow_id = db_register_full_action["flow_define"].id
     def prepare_activity(act_id, recid, with_item=False, is_deleted=False):
         if with_item:
@@ -6330,8 +6283,6 @@ def test_check_authority_action2(app, client, users, db_register_full_action, mo
                                 contain_login_item_application=False,
                                 action_order=1)
 
-# .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_withdraw_confirm_nologin -v -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
-
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_withdraw_confirm_nologin -v -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_withdraw_confirm_nologin(client,db_register2):
@@ -6354,7 +6305,10 @@ def test_withdraw_confirm_nologin(client,db_register2):
     (5, 403, False),
     (6, 403, True),
 ])
-def test_withdraw_confirm_users(client, users, db_register_fullaction, users_index, status_code, is_admin):
+def test_withdraw_confirm_users(
+    client, users, db_register_fullaction, without_remove_session,
+    users_index, status_code, is_admin
+):
     """Test of withdraw confirm."""
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.withdraw_confirm',
@@ -6428,7 +6382,9 @@ def test_withdraw_confirm_guestlogin(guest, client, db_register_fullaction):
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_withdraw_confirm_exception1 -v -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 @pytest.mark.parametrize('users_index', [0, 1, 2, 3, 4, 5, 6])
-def test_withdraw_confirm_exception1(client, users, db_register_fullaction, users_index):
+def test_withdraw_confirm_exception1(
+    client, users, db_register_fullaction, without_remove_session, users_index
+):
     """Test of withdraw confirm."""
     login(client=client, email=users[users_index]['email'])
     url = url_for('weko_workflow.withdraw_confirm', activity_id='1',
@@ -6690,11 +6646,12 @@ def test_get_data_init(client, users):
                 assert response['init_workflows'] == workflows
                 assert response['init_roles'] == roles
                 assert response['logged_roles'] == [
-                    {'id': 3, 'name': 'Contributor'},
-                    {'id': 4, 'name': 'Community Administrator'},
-                    {'id': 5, 'name': 'General'},
-                    {'id': 6, 'name': 'Original Role'},
-                    {'id': 7, 'name': 'Student'}
+                    {"id": "General", "name": "General"},
+                    {"id": "Original Role", "name": "Original Role"},
+                    {"id": "Student", "name": "Student"},
+                    {"id": "Community Administrator", "name": "Community Administrator"},
+                    {"id": "Contributor", "name": "Contributor"},
+                    {"id": "community_role", "name": "community_role"},
                 ]
                 assert response['init_terms'] == terms
 
@@ -6720,7 +6677,10 @@ def test_download_activitylog_nologin(client,db_register2):
     (5, 403),
     (6, 200),
 ])
-def test_download_activitylog_1(client, db, db_register_full_action , users, users_index, status_code):
+def test_download_activitylog_1(
+    client, db, db_register_full_action , users, without_remove_session,
+    users_index, status_code
+):
     """Test of download_activitylog."""
     login(client=client, email=users[users_index]['email'])
 
@@ -6752,7 +6712,10 @@ def test_download_activitylog_1(client, db, db_register_full_action , users, use
     (2, 200),
     (6, 200),
 ])
-def test_download_activitylog_2(client, db_register_full_action, users, users_index, status_code):
+def test_download_activitylog_2(
+    client, db_register_full_action, users, without_remove_session,
+    users_index, status_code
+):
     """Test of download_activitylog."""
     login(client=client, email=users[users_index]['email'])
 
@@ -6960,11 +6923,11 @@ def test_ActivityActionResource_post(client, db_register_full_action, users):
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_SaveActivitySchema -vv -s --cov-branch --cov-report=term --cov-report=html --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 def test_SaveActivitySchema():
     json = {'activity_id': '11', 'shared_user_ids': [{'user': 1},{'user':2}], 'approval1':'', 'approval2':''}
-    data = SaveActivitySchema().load(json)
-    assert data.data['activity_id'] == '11'
-    assert data.data['shared_user_ids'] == [{'user': 1},{'user':2}]
-    assert data.data['approval1'] == ''
-    assert data.data['approval2'] == ''
+    payload = SaveActivitySchema().load(json)
+    assert payload['activity_id'] == '11'
+    assert payload['shared_user_ids'] == [{'user': 1},{'user':2}]
+    assert payload['approval1'] == ''
+    assert payload['approval2'] == ''
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_edit_item_direct_1 -vv -s --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 @pytest.mark.parametrize('users_index, status_code', [
@@ -7006,7 +6969,7 @@ def test_edit_item_direct_after_login_01(client, users, db_register_full_action,
     mock_sessionstorage = MagicMock(redis=mock_redis)
     mocker.patch.object(RedisConnection, 'connection', return_value = mock_sessionstorage)
     mocker.patch('weko_workflow.views.has_comadmin_permission', return_value=True)
-    mocker.patch('celery.task.control.inspect.ping', return_value="")
+    mocker.patch("weko_workflow.utils.current_celery_app.control.inspect.ping", return_value="")
     return_data = MagicMock(activity_id=1)
     mocker.patch("weko_workflow.views.prepare_edit_workflow", return_value=return_data)
     login(client=client, email=users[users_index]["email"])
@@ -7193,7 +7156,7 @@ def test_edit_item_direct_after_login_07(client, users, db_register_full_action,
 )
 def test_edit_item_direct_after_login_08(client, users, db_register_full_action, users_index, status_code, mocker):
     mock_render_template = mocker.patch('weko_workflow.views.render_template', return_value ='')
-    mocker.patch('celery.task.control.inspect.ping', return_value="")
+    mocker.patch('weko_workflow.utils.current_celery_app.control.inspect.ping', return_value="")
     mocker.patch('weko_workflow.views.has_comadmin_permission', return_value=True)
     mocker.patch('weko_workflow.views.check_item_is_being_edit', return_value = "1")
     login(client=client, email=users[users_index]["email"])
@@ -7218,15 +7181,17 @@ def test_edit_item_direct_after_login_09(client, users, db_register_full_action,
     mock_sessionstorage = MagicMock(redis=mock_redis)
     mocker.patch.object(RedisConnection, 'connection', return_value = mock_sessionstorage)
     mocker.patch('weko_workflow.views.has_comadmin_permission', return_value=True)
-    mocker.patch('celery.task.control.inspect.ping', return_value='')
+    mocker.patch('weko_workflow.utils.current_celery_app.control.inspect.ping', return_value='')
     mock_get_workflow_activity_by_item_id = mocker.patch.object(WorkActivity, 'get_workflow_activity_by_item_id', return_value = None)
     mocker.patch('weko_workflow.views.get_workflow_by_item_type_id', return_value=None)
     login(client=client, email=users[users_index]["email"])
     url = url_for("weko_workflow.edit_item_direct_after_login", pid_value="1")
     res = client.get(url)
-    assert mock_get_workflow_activity_by_item_id.call_count == 2
+    # edit_item_direct_after_login (call count: 2) + check_item_is_being_edit (call count: 3) = 5
+    assert mock_get_workflow_activity_by_item_id.call_count == 5
     mock_render_template.assert_called_with("weko_theme/error.html", error="Workflow setting does not exist.")
     assert res.status_code == status_code
+
 
 # .tox/c1/bin/pytest --cov=weko_workflow tests/test_views.py::test_edit_item_direct_after_login_10 -v --cov-branch --cov-report=term --basetemp=/code/modules/weko-workflow/.tox/c1/tmp
 @pytest.mark.parametrize(
@@ -7244,7 +7209,7 @@ def test_edit_item_direct_after_login_10(client, users, db_register_full_action,
     mock_sessionstorage = MagicMock(redis=mock_redis)
     mocker.patch.object(RedisConnection, 'connection', return_value = mock_sessionstorage)
     mocker.patch('weko_workflow.views.has_comadmin_permission', return_value=True)
-    mocker.patch('celery.task.control.inspect.ping', return_value="")
+    mocker.patch("weko_workflow.utils.current_celery_app.control.inspect.ping", return_value="")
     mock_get_workflow_activity_by_item_id = mocker.patch.object(WorkActivity, 'get_workflow_activity_by_item_id', return_value = None)
     return_data_1 = MagicMock(id="1", flow_id="1")
     mocker.patch('weko_workflow.views.get_workflow_by_item_type_id', return_value=return_data_1)
@@ -7253,7 +7218,8 @@ def test_edit_item_direct_after_login_10(client, users, db_register_full_action,
     login(client=client, email=users[users_index]["email"])
     url = url_for("weko_workflow.edit_item_direct_after_login", pid_value="1")
     res = client.get(url)
-    assert mock_get_workflow_activity_by_item_id.call_count == 2
+    # edit_item_direct_after_login (call count: 2) + check_item_is_being_edit (call count: 3) = 5
+    assert mock_get_workflow_activity_by_item_id.call_count == 5
     assert res.status_code == status_code
     assert res.location == 'http://test_server.localdomain/workflow/activity/detail/1'
 
@@ -7273,7 +7239,7 @@ def test_edit_item_direct_after_login_11(client, users, db_register_full_action,
     mock_sessionstorage = MagicMock(redis=mock_redis)
     mocker.patch.object(RedisConnection, 'connection', return_value = mock_sessionstorage)
     mocker.patch('weko_workflow.views.has_comadmin_permission', return_value=True)
-    mocker.patch('celery.task.control.inspect.ping', return_value="")
+    mocker.patch("weko_workflow.utils.current_celery_app.control.inspect.ping", return_value="")
     mocker.patch("weko_workflow.views.prepare_edit_workflow", side_effect=SQLAlchemyError)
     login(client=client, email=users[users_index]["email"])
     url = url_for("weko_workflow.edit_item_direct_after_login", pid_value="1")
@@ -7297,7 +7263,7 @@ def test_edit_item_direct_after_login_12(client, users, db_register_full_action,
     mock_sessionstorage = MagicMock(redis=mock_redis)
     mocker.patch.object(RedisConnection, 'connection', return_value = mock_sessionstorage)
     mocker.patch('weko_workflow.views.has_comadmin_permission', return_value=True)
-    mocker.patch('celery.task.control.inspect.ping', return_value="")
+    mocker.patch("weko_workflow.utils.current_celery_app.control.inspect.ping", return_value="")
     mocker.patch("weko_workflow.views.prepare_edit_workflow", side_effect=BaseException)
     login(client=client, email=users[users_index]["email"])
     url = url_for("weko_workflow.edit_item_direct_after_login", pid_value="1")

--- a/modules/weko-workflow/weko_workflow/admin.py
+++ b/modules/weko-workflow/weko_workflow/admin.py
@@ -257,6 +257,7 @@ class FlowSettingView(BaseView):
         """Update FlowAction Info."""
         if not self._check_auth(str(flow_id)) :
             abort(403)
+        actions = None
         try:
             actions = request.get_json()
             workflow = Flow()

--- a/modules/weko-workflow/weko_workflow/utils.py
+++ b/modules/weko-workflow/weko_workflow/utils.py
@@ -4214,8 +4214,11 @@ def process_send_mail_tpl(mail_info, mail_pattern_name):
 def cancel_expired_usage_reports():
     """Cancel expired usage reports."""
     expired_activities = GuestActivity.get_expired_activities()
-    if expired_activities:
-        WorkActivity().cancel_usage_report_activities(expired_activities)
+    expired_activity_ids = [
+        activity.activity_id for activity in expired_activities
+    ]
+    if expired_activity_ids:
+        WorkActivity().cancel_usage_report_activities(expired_activity_ids)
 
 
 def process_send_approval_mails(activity_detail, actions_mail_setting,

--- a/modules/weko-workflow/weko_workflow/views.py
+++ b/modules/weko-workflow/weko_workflow/views.py
@@ -30,6 +30,7 @@ from invenio_pidstore.errors import PIDDoesNotExistError,PIDDeletedError
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from invenio_rest import ContentNegotiatedMethodView
 from marshmallow.exceptions import ValidationError
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from typing import List
 from urllib.parse import urljoin
@@ -1598,8 +1599,8 @@ def next_action(activity_id='0', action_id=0, json_data=None):
         activity_detail.flow_define.flow_id, action_id, action_order)
     if current_flow_action is None:
         current_app.logger.error("next_action: can not get current_flow_action")
-        res = ResponseMessageSchema().load({"code":-1, "msg":"can not get curretn_flow_action"})
-        return jsonify(res.data), 500
+        res = ResponseMessageSchema().load({"code":-1, "msg":"can not get current_flow_action"})
+        return jsonify(res), 500
     next_flow_action = flow.get_next_flow_action(
         activity_detail.flow_define.flow_id, action_id, action_order)
     if not isinstance(next_flow_action, list) or len(next_flow_action) <= 0:
@@ -2003,7 +2004,7 @@ def next_action(activity_id='0', action_id=0, json_data=None):
             )
             if new_item_id is None:
                 res = ResponseMessageSchema().load({"code":-1, "msg":_("error")})
-                return jsonify(res.data), 500
+                return jsonify(res), 500
 
             activity.update(
                 action_id=next_action_id,
@@ -2928,16 +2929,21 @@ def get_request_maillist(activity_id='0'):
     check_flg = type_null_check(activity_id, str)
     if not check_flg:
         current_app.logger.error("get_request_maillist: argument error")
-        res = ResponseMessageSchema().load({"code":-1, "msg":"arguments error"})
-        return jsonify(res.data), 400
+        error_payload = ResponseMessageSchema().load({"code":-1, "msg":"arguments error"})
+        return jsonify(error_payload), 400
     try:
         activity_request_mail = WorkActivity().get_activity_request_mail(
             activity_id=activity_id)
         if activity_request_mail:
             request_mail_list = activity_request_mail.request_maillist
             if not isinstance(request_mail_list, list):
-                res = ResponseMessageSchema().load({"code":-1,"msg":"mail_list is not list"})
-                return jsonify(res.data), 400
+                error_payload = ResponseMessageSchema().load(
+                    {
+                        "code":-1,
+                        "msg":"mail_list is not list"
+                    }
+                )
+                return jsonify(error_payload), 400
             temp_list = []
             added_user = []
             for mail in request_mail_list.copy():
@@ -2952,20 +2958,23 @@ def get_request_maillist(activity_id='0'):
                         ]
                         added_user.append(aid)
             request_mail_list += temp_list
-            res = GetRequestMailListSchema().load({
+            request_mails_payload = GetRequestMailListSchema().load({
                 'code':1,
                 'msg':_('Success'),
                 'request_maillist': request_mail_list,
                 'is_display_request_button': activity_request_mail.display_request_button
             })
-            return jsonify(res.data), 200
+            return jsonify(request_mails_payload), 200
         else:
-            res = ResponseMessageSchema().load({'code':0,'msg':'Empty!'})
-            return jsonify(res.data), 200
+            empty_data_payload = ResponseMessageSchema().load(
+                {"code": 0,"msg": "Empty!"}
+            )
+            return jsonify(empty_data_payload), 200
     except Exception:
         current_app.logger.exception("Unexpected error:")
-    res = ResponseMessageSchema().load({'code':-1,'msg':_('Error')})
-    return jsonify(res.data), 400
+
+    error_payload = ResponseMessageSchema().load({'code':-1,'msg':_('Error')})
+    return jsonify(error_payload), 400
 
 
 @workflow_blueprint.route('/activity/unlocks/<string:activity_id>',methods=["POST"])
@@ -3098,26 +3107,28 @@ def get_item_application(activity_id='0'):
     check_flg = type_null_check(activity_id, str)
     if not check_flg:
         current_app.logger.error("get_item_application: argument error")
-        res = ResponseMessageSchema().load({"code":-1, "msg":"arguments error"})
-        return jsonify(res.data), 400
+        error_payload = ResponseMessageSchema().load({"code":-1, "msg":"arguments error"})
+        return jsonify(error_payload), 400
     try:
         item_application_and_button = WorkActivity().get_activity_item_application(
             activity_id=activity_id)
         if item_application_and_button:
-            res = GetItemApplicationSchema().load({
+            item_application_payload = GetItemApplicationSchema().load({
                 'code':1,
                 'msg':_('Success'),
                 'item_application': item_application_and_button.item_application,
                 'is_display_item_application_button': item_application_and_button.display_item_application_button
             })
-            return jsonify(res.data), 200
+            return jsonify(item_application_payload), 200
         else:
-            res = ResponseMessageSchema().load({'code':0,'msg':'Empty!'})
-            return jsonify(res.data), 200
+            empty_data_payload = ResponseMessageSchema().load(
+                {"code": 0,"msg": "Empty!"}
+            )
+            return jsonify(empty_data_payload), 200
     except Exception:
         current_app.logger.exception("Unexpected error:")
-    res = ResponseMessageSchema().load({'code':-1,'msg':_('Error')})
-    return jsonify(res.data), 400
+    error_payload = ResponseMessageSchema().load({'code':-1,'msg':_('Error')})
+    return jsonify(error_payload), 400
 
 @workflow_blueprint.route('/activity/lock/<string:activity_id>', methods=['POST'])
 @login_required
@@ -3303,7 +3314,7 @@ def unlock_activity(activity_id="0"):
     except ValidationError as err:
         res = ResponseMessageSchema().load({'code':-1, 'msg':str(err)})
         return jsonify(res), 400
-    msg = delete_lock_activity_cache(activity_id, data.data)
+    msg = delete_lock_activity_cache(activity_id, data)
     res = ResponseUnlockSchema().load({'code':200,'msg':msg or _('Not unlock')})
     return jsonify(res), 200
 
@@ -3502,16 +3513,27 @@ def get_data_init():
     init_workflows = get_workflows()
     init_roles = get_roles()
     init_terms = get_terms()
-    roles = Role.query.all()
-    logged_roles = []
-    for role in roles:
-        if role.id > 2:
-            logged_roles.append({'id': role.id, 'name': role.name})
+
+    # Get super role names from the current app configuration
+    super_role_names = [
+        current_app.config["WEKO_ADMIN_PERMISSION_ROLE_SYSTEM"],
+        current_app.config["WEKO_ADMIN_PERMISSION_ROLE_REPO"]
+    ]
+
+    # Query the database for roles that are not superuser roles
+    non_superuser_roles = db.session.scalars(
+        select(Role).where(~Role.name.in_(super_role_names))
+    ).all()
+    restricted_record_access_roles = [
+        {"id": role.id, "name": role.name} for role in non_superuser_roles
+    ]
+
     return jsonify(
         init_workflows=init_workflows,
         init_roles=init_roles,
-        logged_roles = logged_roles,
-        init_terms=init_terms)
+        logged_roles=restricted_record_access_roles,
+        init_terms=init_terms,
+    )
 
 
 @workflow_blueprint.route('/download_activitylog/', methods=['GET','POST'])


### PR DESCRIPTION
- 参照エラーの発生を防ぐため、`FlowSettingView` 内で `actions` 変数の宣言・初期化を追加
- 有効期限が切れたアクティビティ ID をより効率的に処理できるよう、`cancel_expired_usage_reports` を更新
- `next_action`、`get_request_maillist`、および `get_item_application` におけるエラー処理を改善し、`.data` にアクセスする代わりに、レスポンスのペイロードを直接返すよう変更
- `get_data_init` におけるロールの取得機能を設定に基づいてスーパーユーザーロールを除外するよう修正
- 以前の仕様に合わせるため、 ヘッダの Location を絶対パスに変換するような設定、処理を追加
     - Werkzeug のライブラリ更新に伴う、仕様変更の影響差異吸収